### PR TITLE
perf: Pi 런타임 품질 개선

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -139,5 +139,5 @@ docs/
 ## Reliability Notes
 
 - JSON 추출 실패 시 주요 에이전트는 최대 2회 재시도합니다.
-- 이벤트 레코더는 세션 스트림과 provider retry 이벤트를 `events.json`에 남깁니다.
-- 스크리닝은 `SessionPool(3)`으로 병렬도를 제한해 펀더멘털 분석을 수행합니다.
+- 이벤트 레코더는 세션 스트림, provider retry metadata, provider error metadata를 `events.json`에 남깁니다.
+- 스크리닝은 기본 병렬도 3으로 펀더멘털 분석을 수행하며, `DURE_MAX_CONCURRENT_SESSIONS`로 조정할 수 있습니다.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -105,6 +105,12 @@ Gemini를 제3자 코딩 에이전트에서 사용해야 한다면 제품 로그
 | Review Checklist | `openai-codex:gpt-4.5-mini` |
 | Router | `openai-codex:gpt-5.3-codex-spark` |
 
+## Runtime Tuning
+
+| 변수 | 설명 |
+|------|------|
+| `DURE_MAX_CONCURRENT_SESSIONS` | workflow 내부 병렬 agent session 수 제한. 기본값은 `3`이며, 1 이상의 정수만 허용합니다. |
+
 ## Command Notes
 
 - 패키지 스크립트는 `tsx --env-file=.env src/main.ts ...` 형태로 실행됩니다.

--- a/src/agents/reviewChecklistAgent.ts
+++ b/src/agents/reviewChecklistAgent.ts
@@ -73,6 +73,7 @@ export async function runReviewChecklistAgent(
   const sourceType = validateSourceRunId(input.sourceRunId);
   const evidence = await loadEquityEvidenceBundle(input.sourceRunId);
   const evidenceBundle = buildEvidenceBundle(input.sourceRunId, evidence);
+  const evidenceSummary = buildEvidenceSummary(input.sourceRunId, evidence);
 
   const reviewerSettled = await Promise.allSettled(
     REVIEWER_SPECS.map(async (spec) => {
@@ -125,7 +126,7 @@ export async function runReviewChecklistAgent(
   } else {
     finalReview = await runSynthesizerSession({
       sourceRunId: input.sourceRunId,
-      evidenceBundle,
+      evidenceSummary,
       reviewers: {
         companyAnalysis: reviewers.companyAnalysis ?? '',
         riskManagement: reviewers.riskManagement ?? '',
@@ -283,6 +284,39 @@ function buildEvidenceBundle(sourceRunId: string, evidence: EquityEvidenceBundle
   return sections.join('\n');
 }
 
+function buildEvidenceSummary(sourceRunId: string, evidence: EquityEvidenceBundle): string {
+  return [
+    `Source Run ID: ${sourceRunId}`,
+    `Universe Included: ${evidence.universe ? 'yes' : 'no'}`,
+    `Fundamental Artifacts: ${evidence.fundamentals.length}`,
+    `News Artifacts: ${evidence.newsAnalyses.length}`,
+    `Strategy Summary: ${summarizeJson(evidence.strategy)}`,
+    `Critic Summary: ${summarizeJson(evidence.critic)}`,
+  ].join('\n');
+}
+
+function summarizeJson(value: unknown): string {
+  if (!value || typeof value !== 'object') {
+    return JSON.stringify(value);
+  }
+
+  const objectValue = value as Record<string, unknown>;
+  const summaryKeys = ['name', 'hypothesis', 'verdict', 'recommendations'];
+  const summary: Record<string, unknown> = {};
+
+  for (const key of summaryKeys) {
+    if (key in objectValue) {
+      summary[key] = objectValue[key];
+    }
+  }
+
+  if (Object.keys(summary).length === 0) {
+    return `keys=${Object.keys(objectValue).join(', ')}`;
+  }
+
+  return JSON.stringify(summary);
+}
+
 async function runReviewSession(params: {
   label: string;
   promptNames: PromptName[];
@@ -319,7 +353,7 @@ async function runReviewSession(params: {
 
 async function runSynthesizerSession(params: {
   sourceRunId: string;
-  evidenceBundle: string;
+  evidenceSummary: string;
   reviewers: Required<Omit<ReviewChecklistReviewers, 'fallback'>>;
   recorder: EventRecorder;
   onUpdate?: AgentToolUpdateCallback<null>;
@@ -341,8 +375,8 @@ async function runSynthesizerSession(params: {
       `Source Run ID: ${params.sourceRunId}`,
       'Return concise Markdown using the required headings.',
       '',
-      '=== Original Evidence Bundle ===',
-      params.evidenceBundle,
+      '=== Source Summary ===',
+      params.evidenceSummary,
       '',
       '=== Company Analysis Reviewer ===',
       params.reviewers.companyAnalysis,

--- a/src/runtime/createPiSession.ts
+++ b/src/runtime/createPiSession.ts
@@ -9,6 +9,7 @@ import {
   ModelRegistry,
   readOnlyTools,
   SessionManager,
+  SettingsManager,
   type ToolDefinition,
 } from '@mariozechner/pi-coding-agent';
 import { type AgentName, getAgentModel } from '../config.js';
@@ -24,6 +25,77 @@ export interface AgentSessionOptions {
   onUpdate?: AgentToolUpdateCallback<null>;
 }
 
+interface PiRuntimeServices {
+  agentDir: string;
+  authStorage: AuthStorage;
+  modelRegistry: ModelRegistry;
+  settingsManager: SettingsManager;
+}
+
+let servicesCache: PiRuntimeServices | undefined;
+const resourceLoaderCache = new Map<string, Promise<DefaultResourceLoader>>();
+
+function getPiRuntimeServices(): PiRuntimeServices {
+  if (!servicesCache) {
+    const agentDir = getAgentDir();
+    const authStorage = AuthStorage.create(`${agentDir}/auth.json`);
+    const modelRegistry = ModelRegistry.create(authStorage);
+    const settingsManager = SettingsManager.inMemory({
+      retry: {
+        enabled: true,
+        maxRetries: 3,
+        baseDelayMs: 1000,
+        maxDelayMs: 10000,
+      },
+      compaction: {
+        enabled: true,
+      },
+    });
+
+    servicesCache = {
+      agentDir,
+      authStorage,
+      modelRegistry,
+      settingsManager,
+    };
+  }
+
+  return servicesCache;
+}
+
+async function getResourceLoader(params: {
+  cwd: string;
+  agentDir: string;
+  settingsManager: SettingsManager;
+  systemPrompt: string;
+}): Promise<DefaultResourceLoader> {
+  const key = JSON.stringify({
+    cwd: params.cwd,
+    agentDir: params.agentDir,
+    systemPrompt: params.systemPrompt,
+  });
+  let cached = resourceLoaderCache.get(key);
+  if (!cached) {
+    cached = (async () => {
+      const loader = new DefaultResourceLoader({
+        cwd: params.cwd,
+        agentDir: params.agentDir,
+        settingsManager: params.settingsManager,
+        systemPrompt: params.systemPrompt,
+        noExtensions: true,
+        noSkills: true,
+        noPromptTemplates: true,
+        noThemes: true,
+      });
+      await loader.reload();
+      return loader;
+    })();
+    resourceLoaderCache.set(key, cached);
+  }
+
+  return cached;
+}
+
 export async function createPiSession(options: AgentSessionOptions): Promise<AgentSession> {
   const {
     agentName,
@@ -35,23 +107,17 @@ export async function createPiSession(options: AgentSessionOptions): Promise<Age
     onUpdate,
   } = options;
 
-  const agentDir = getAgentDir();
-  const authStorage = AuthStorage.create(`${agentDir}/auth.json`);
-  const modelRegistry = ModelRegistry.create(authStorage);
+  const { agentDir, modelRegistry, settingsManager } = getPiRuntimeServices();
 
   const modelConfig = getAgentModel(agentName);
   const model = modelRegistry.find(modelConfig.provider, modelConfig.modelId);
 
-  const resourceLoader = new DefaultResourceLoader({
+  const resourceLoader = await getResourceLoader({
     cwd: process.cwd(),
     agentDir,
+    settingsManager,
     systemPrompt,
-    noExtensions: true,
-    noSkills: true,
-    noPromptTemplates: true,
-    noThemes: true,
   });
-  await resourceLoader.reload();
 
   const builtInTools = useCodeTools ? codingTools : readOnlyTools;
 
@@ -62,6 +128,7 @@ export async function createPiSession(options: AgentSessionOptions): Promise<Age
     tools: builtInTools,
     customTools: customTools ?? [],
     resourceLoader,
+    settingsManager,
   });
 
   if (eventRecorder) {

--- a/src/runtime/eventRecorder.ts
+++ b/src/runtime/eventRecorder.ts
@@ -17,6 +17,7 @@ interface RecordedEvent {
 export class EventRecorder {
   private events: RecordedEvent[] = [];
   private unsubscribes: (() => void)[] = [];
+  private turnStarts = new Map<string, number>();
 
   constructor(private readonly logSink?: PiLogSink) {}
 
@@ -31,11 +32,17 @@ export class EventRecorder {
     let buffer = '';
 
     const unsub = session.subscribe((event: AgentSessionEvent) => {
+      const timestamp = Date.now();
       this.events.push({
-        timestamp: Date.now(),
+        timestamp,
         sessionLabel,
         type: event.type,
+        data: getRecordedEventData(event, this.turnStarts.get(sessionLabel), timestamp),
       });
+
+      if (event.type === 'turn_start') {
+        this.turnStarts.set(sessionLabel, timestamp);
+      }
 
       if (
         event.type === 'message_update' &&
@@ -94,5 +101,48 @@ export class EventRecorder {
   dispose(): void {
     for (const unsub of this.unsubscribes) unsub();
     this.unsubscribes = [];
+    this.turnStarts.clear();
   }
+}
+
+function getRecordedEventData(
+  event: AgentSessionEvent,
+  turnStart: number | undefined,
+  timestamp: number,
+): Record<string, unknown> | undefined {
+  if (event.type === 'turn_end') {
+    const msg = event.message as unknown as Record<string, unknown> | undefined;
+    return removeUndefinedValues({
+      role: msg?.role,
+      stopReason: msg?.stopReason,
+      errorMessage: msg?.errorMessage,
+      durationMs: turnStart ? timestamp - turnStart : undefined,
+    });
+  }
+
+  if (event.type === 'auto_retry_start') {
+    return {
+      attempt: event.attempt,
+      maxAttempts: event.maxAttempts,
+      delayMs: event.delayMs,
+      errorMessage: event.errorMessage,
+    };
+  }
+
+  if (event.type === 'auto_retry_end') {
+    return removeUndefinedValues({
+      success: event.success,
+      attempt: event.attempt,
+      finalError: event.finalError,
+    });
+  }
+
+  return undefined;
+}
+
+function removeUndefinedValues(data: Record<string, unknown>): Record<string, unknown> | undefined {
+  const compact = Object.fromEntries(
+    Object.entries(data).filter(([, value]) => value !== undefined),
+  );
+  return Object.keys(compact).length > 0 ? compact : undefined;
 }

--- a/src/runtime/sessionPool.ts
+++ b/src/runtime/sessionPool.ts
@@ -2,7 +2,7 @@ export class SessionPool {
   private running = 0;
   private queue: Array<() => void> = [];
 
-  constructor(private maxConcurrent = 3) {}
+  constructor(private maxConcurrent = getDefaultMaxConcurrentSessions()) {}
 
   async acquire<T>(fn: () => Promise<T>): Promise<T> {
     if (this.running >= this.maxConcurrent) {
@@ -17,4 +17,14 @@ export class SessionPool {
       if (next) next();
     }
   }
+}
+
+export function getDefaultMaxConcurrentSessions(): number {
+  const raw = process.env.DURE_MAX_CONCURRENT_SESSIONS;
+  if (!raw) return 3;
+
+  const parsed = Number(raw);
+  if (!Number.isInteger(parsed) || parsed < 1) return 3;
+
+  return parsed;
 }

--- a/src/tools/workflowTools.ts
+++ b/src/tools/workflowTools.ts
@@ -66,7 +66,7 @@ const screeningParams = Type.Object({
   market: Type.Optional(Type.String({ description: '시장 (예: KR, KOSPI)' })),
   style: Type.Optional(Type.String({ description: '투자 스타일 (예: value, growth)' })),
   filterRules: Type.Optional(Type.String({ description: '스크리닝 필터 규칙' })),
-  topN: Type.Optional(Type.Number({ description: '상위 N개 종목 반환 (기본: 10)' })),
+  topN: Type.Optional(Type.Number({ description: '상위 N개 종목 반환 (기본: 5)' })),
 });
 
 export const screeningTool: ToolDefinition<typeof screeningParams, WorkflowToolDetails> = {

--- a/src/workflow/runEquityAnalysis.ts
+++ b/src/workflow/runEquityAnalysis.ts
@@ -34,7 +34,7 @@ export async function runEquityAnalysis(
   const runId = `equity-${Date.now()}`;
   const store = new ArtifactStore();
   const recorder = new EventRecorder();
-  const pool = new SessionPool(3);
+  const pool = new SessionPool();
   const emit = onUpdate ? createOnUpdateLogger(onUpdate) : log;
   let universe: unknown;
 

--- a/src/workflow/runScenarioAnalysis.ts
+++ b/src/workflow/runScenarioAnalysis.ts
@@ -30,7 +30,7 @@ export async function runScenarioAnalysis(
   const runId = `scenario-${Date.now()}`;
   const store = new ArtifactStore();
   const recorder = new EventRecorder();
-  const pool = new SessionPool(3);
+  const pool = new SessionPool();
   const emit = onUpdate ? createOnUpdateLogger(onUpdate) : log;
 
   emit(`\n[run] 시나리오 분석 시작: ${runId}`);

--- a/src/workflow/runScreening.ts
+++ b/src/workflow/runScreening.ts
@@ -26,7 +26,7 @@ export async function runScreening(
   const runId = `screen-${Date.now()}`;
   const store = new ArtifactStore();
   const recorder = new EventRecorder();
-  const pool = new SessionPool(3);
+  const pool = new SessionPool();
   const emit = onUpdate ? createOnUpdateLogger(onUpdate) : log;
 
   emit(`\n[run] 스크리닝 시작: ${runId}`);

--- a/src/workflow/runStrategyResearch.ts
+++ b/src/workflow/runStrategyResearch.ts
@@ -30,22 +30,20 @@ export async function runStrategyResearch(
 
   emit(`\n[run] 전략 리서치 시작: ${runId}`);
 
+  const theme = options.tickers?.length
+    ? `${options.theme}\n대상 종목: ${options.tickers.join(', ')}`
+    : options.theme;
+
   // 1. 전략 설계
   emit('[run] 전략 설계 중...');
-  const strategy = await runStrategyAgent(
-    runId,
-    { theme: options.theme },
-    store,
-    recorder,
-    onUpdate,
-  );
+  const strategy = await runStrategyAgent(runId, { theme }, store, recorder, onUpdate);
 
   // 2. Critic autoresearch (최대 3회 반복)
   const loopResult = await runCriticIterationLoop(
     {
       runId,
       initialStrategy: strategy,
-      theme: options.theme,
+      theme,
       maxIterations: options.maxIterations,
     },
     store,

--- a/tests/agents/reviewChecklistAgent.test.ts
+++ b/tests/agents/reviewChecklistAgent.test.ts
@@ -167,6 +167,12 @@ describe('runReviewChecklistAgent', () => {
     expect(
       promptCalls.find((call) => call.label.includes('synthesizer:'))?.userMessage,
     ).toContain('Company Analysis: valuation bridge is weak');
+    expect(
+      promptCalls.find((call) => call.label.includes('synthesizer:'))?.userMessage,
+    ).toContain('=== Source Summary ===');
+    expect(
+      promptCalls.find((call) => call.label.includes('synthesizer:'))?.userMessage,
+    ).not.toContain('=== Original Evidence Bundle ===');
 
     expect(result.sourceType).toBe('equity');
     expect(result.reviewers.companyAnalysis).toContain('Company Analysis');

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -1,0 +1,47 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { getAgentModel } from '../src/config.js';
+
+describe('getAgentModel', () => {
+  const originalEnv = { ...process.env };
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it('개별 agent override가 전역 provider보다 우선한다', () => {
+    process.env.DURE_PROVIDER = 'anthropic';
+    process.env.DURE_MODEL_NEWS = 'openai-codex:gpt-custom';
+
+    expect(getAgentModel('news')).toEqual({
+      provider: 'openai-codex',
+      modelId: 'gpt-custom',
+    });
+  });
+
+  it('전역 provider preset을 사용한다', () => {
+    process.env.DURE_PROVIDER = 'anthropic';
+
+    expect(getAgentModel('critic')).toEqual({
+      provider: 'anthropic',
+      modelId: 'claude-opus-4-6',
+    });
+  });
+
+  it('알 수 없는 provider는 provider만 바꾸고 기본 modelId를 유지한다', () => {
+    process.env.DURE_PROVIDER = 'local';
+
+    expect(getAgentModel('router')).toEqual({
+      provider: 'local',
+      modelId: 'gpt-5.3-codex-spark',
+    });
+  });
+
+  it('잘못된 개별 override는 무시하고 fallback한다', () => {
+    process.env.DURE_MODEL_STRATEGY = 'malformed';
+
+    expect(getAgentModel('strategy')).toEqual({
+      provider: 'openai-codex',
+      modelId: 'gpt-5.4',
+    });
+  });
+});

--- a/tests/runtime/createPiSession.test.ts
+++ b/tests/runtime/createPiSession.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  authStorageCreate: vi.fn(() => ({ kind: 'auth' })),
+  modelRegistryCreate: vi.fn(() => ({
+    find: vi.fn(() => ({ kind: 'model' })),
+  })),
+  settingsManagerInMemory: vi.fn(() => ({ kind: 'settings' })),
+  resourceLoaderReload: vi.fn(async () => undefined),
+  createAgentSession: vi.fn(async () => ({
+    session: {
+      subscribe: vi.fn(() => () => undefined),
+    },
+  })),
+  getAgentDir: vi.fn(() => '/tmp/pi-agent'),
+  resourceLoaderConstructs: [] as unknown[],
+}));
+
+vi.mock('@mariozechner/pi-coding-agent', () => {
+  class DefaultResourceLoader {
+    constructor(options: unknown) {
+      mocks.resourceLoaderConstructs.push(options);
+    }
+
+    reload = mocks.resourceLoaderReload;
+  }
+
+  return {
+    AuthStorage: { create: mocks.authStorageCreate },
+    ModelRegistry: { create: mocks.modelRegistryCreate },
+    SettingsManager: { inMemory: mocks.settingsManagerInMemory },
+    DefaultResourceLoader,
+    SessionManager: { inMemory: vi.fn(() => ({ kind: 'session-manager' })) },
+    createAgentSession: mocks.createAgentSession,
+    getAgentDir: mocks.getAgentDir,
+    codingTools: ['coding-tool'],
+    readOnlyTools: ['read-only-tool'],
+  };
+});
+
+describe('createPiSession', () => {
+  afterEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    mocks.resourceLoaderConstructs.length = 0;
+  });
+
+  it('process-local runtime services와 같은 systemPrompt resource loader를 재사용한다', async () => {
+    const { createPiSession } = await import('../../src/runtime/createPiSession.js');
+
+    await createPiSession({
+      agentName: 'news',
+      sessionLabel: 'news:005930',
+      systemPrompt: 'news prompt',
+    });
+    await createPiSession({
+      agentName: 'news',
+      sessionLabel: 'news:000660',
+      systemPrompt: 'news prompt',
+    });
+
+    expect(mocks.getAgentDir).toHaveBeenCalledTimes(1);
+    expect(mocks.authStorageCreate).toHaveBeenCalledTimes(1);
+    expect(mocks.modelRegistryCreate).toHaveBeenCalledTimes(1);
+    expect(mocks.settingsManagerInMemory).toHaveBeenCalledTimes(1);
+    expect(mocks.resourceLoaderConstructs).toHaveLength(1);
+    expect(mocks.resourceLoaderReload).toHaveBeenCalledTimes(1);
+    expect(mocks.createAgentSession).toHaveBeenCalledTimes(2);
+    expect(mocks.createAgentSession.mock.calls[0]?.[0]).toMatchObject({
+      settingsManager: { kind: 'settings' },
+      tools: ['read-only-tool'],
+    });
+  });
+
+  it('useCodeTools가 켜지면 codingTools를 전달한다', async () => {
+    const { createPiSession } = await import('../../src/runtime/createPiSession.js');
+
+    await createPiSession({
+      agentName: 'strategy',
+      sessionLabel: 'strategy:quality',
+      systemPrompt: 'strategy prompt',
+      useCodeTools: true,
+    });
+
+    expect(mocks.createAgentSession.mock.calls.at(-1)?.[0]).toMatchObject({
+      tools: ['coding-tool'],
+    });
+  });
+});

--- a/tests/runtime/eventRecorder.test.ts
+++ b/tests/runtime/eventRecorder.test.ts
@@ -1,10 +1,20 @@
+import { mkdir, readFile, rm } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { EventRecorder } from '../../src/runtime/eventRecorder.js';
 
 describe('EventRecorder', () => {
+  const tempDirs: string[] = [];
+
   afterEach(() => {
     vi.restoreAllMocks();
     vi.useRealTimers();
+    return Promise.all(tempDirs.map((dir) => rm(dir, { recursive: true, force: true }))).then(
+      () => {
+        tempDirs.length = 0;
+      },
+    );
   });
 
   it('onUpdate가 있으면 stderr에 직접 쓰지 않는다', () => {
@@ -45,5 +55,79 @@ describe('EventRecorder', () => {
     expect(latest.content[0].text).toContain('[fundamental:005930] line 1');
     expect(latest.content[0].text).toContain('[fundamental:005930] line 2');
     expect(latest.content[0].text).toContain('[fundamental:005930] --- turn end ---');
+  });
+
+  it('retry와 provider error metadata를 events.json에 저장한다', async () => {
+    let handler: ((event: unknown) => void) | undefined;
+    const session = {
+      subscribe(fn: (event: unknown) => void) {
+        handler = fn;
+        return () => {};
+      },
+    };
+    const recorder = new EventRecorder();
+    recorder.attachToSession('critic:test', session as never);
+
+    handler?.({ type: 'turn_start' });
+    handler?.({
+      type: 'auto_retry_start',
+      attempt: 1,
+      maxAttempts: 3,
+      delayMs: 1000,
+      errorMessage: 'rate limit',
+    });
+    handler?.({
+      type: 'auto_retry_end',
+      success: false,
+      attempt: 3,
+      finalError: 'still rate limited',
+    });
+    handler?.({
+      type: 'turn_end',
+      message: {
+        role: 'assistant',
+        stopReason: 'error',
+        errorMessage: 'provider failed',
+      },
+    });
+
+    const tempDir = path.join(os.tmpdir(), `event-recorder-${Date.now()}`);
+    tempDirs.push(tempDir);
+    await mkdir(tempDir, { recursive: true });
+    await recorder.persist('run-1', tempDir);
+
+    const raw = await readFile(path.join(tempDir, 'run-1', 'events.json'), 'utf-8');
+    const events = JSON.parse(raw);
+
+    expect(events).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'auto_retry_start',
+          data: {
+            attempt: 1,
+            maxAttempts: 3,
+            delayMs: 1000,
+            errorMessage: 'rate limit',
+          },
+        }),
+        expect.objectContaining({
+          type: 'auto_retry_end',
+          data: {
+            success: false,
+            attempt: 3,
+            finalError: 'still rate limited',
+          },
+        }),
+        expect.objectContaining({
+          type: 'turn_end',
+          data: expect.objectContaining({
+            role: 'assistant',
+            stopReason: 'error',
+            errorMessage: 'provider failed',
+            durationMs: expect.any(Number),
+          }),
+        }),
+      ]),
+    );
   });
 });

--- a/tests/runtime/sessionPool.test.ts
+++ b/tests/runtime/sessionPool.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { getDefaultMaxConcurrentSessions, SessionPool } from '../../src/runtime/sessionPool.js';
+
+describe('SessionPool', () => {
+  const originalMaxConcurrent = process.env.DURE_MAX_CONCURRENT_SESSIONS;
+
+  afterEach(() => {
+    if (originalMaxConcurrent === undefined) {
+      delete process.env.DURE_MAX_CONCURRENT_SESSIONS;
+    } else {
+      process.env.DURE_MAX_CONCURRENT_SESSIONS = originalMaxConcurrent;
+    }
+  });
+
+  it('maxConcurrent를 넘지 않고 queued work를 순서대로 진행한다', async () => {
+    const pool = new SessionPool(2);
+    let running = 0;
+    let observedMax = 0;
+
+    await Promise.all(
+      Array.from({ length: 5 }, (_, index) =>
+        pool.acquire(async () => {
+          running++;
+          observedMax = Math.max(observedMax, running);
+          await new Promise((resolve) => setTimeout(resolve, 5));
+          running--;
+          return index;
+        }),
+      ),
+    );
+
+    expect(observedMax).toBe(2);
+  });
+
+  it('rejected task 이후에도 다음 queued work를 실행한다', async () => {
+    const pool = new SessionPool(1);
+    const completed: string[] = [];
+
+    const first = pool
+      .acquire(async () => {
+        completed.push('first');
+        throw new Error('boom');
+      })
+      .catch((error) => error as Error);
+    const second = pool.acquire(async () => {
+      completed.push('second');
+      return 'ok';
+    });
+
+    await expect(first).resolves.toMatchObject({ message: 'boom' });
+    await expect(second).resolves.toBe('ok');
+    expect(completed).toEqual(['first', 'second']);
+  });
+
+  it('DURE_MAX_CONCURRENT_SESSIONS가 유효하면 기본 동시성으로 사용한다', () => {
+    process.env.DURE_MAX_CONCURRENT_SESSIONS = '7';
+
+    expect(getDefaultMaxConcurrentSessions()).toBe(7);
+  });
+
+  it('DURE_MAX_CONCURRENT_SESSIONS가 잘못되면 기본값 3으로 fallback한다', () => {
+    process.env.DURE_MAX_CONCURRENT_SESSIONS = '0';
+    expect(getDefaultMaxConcurrentSessions()).toBe(3);
+
+    process.env.DURE_MAX_CONCURRENT_SESSIONS = 'invalid';
+    expect(getDefaultMaxConcurrentSessions()).toBe(3);
+  });
+});

--- a/tests/workflow/runCriticIterationLoop.test.ts
+++ b/tests/workflow/runCriticIterationLoop.test.ts
@@ -126,6 +126,51 @@ describe('critic autoresearch loops', () => {
     );
   });
 
+  it('strategy research는 tickers context를 전략 생성과 critic에 전달한다', async () => {
+    const strategy = {
+      name: 'Ticker Strategy',
+      hypothesis: 'Ticker-aware hypothesis',
+      entryRules: ['ROE > 0.1'],
+      exitRules: ['ROE < 0.05'],
+      positionSizing: '3%',
+      rebalancePeriod: 'monthly',
+      config: {},
+    };
+    const critic = {
+      verdict: 'keep' as const,
+      recommendations: ['good'],
+      overfittingRisk: 'low',
+      dataLeakageCheck: 'pass',
+      survivorshipBias: 'low',
+      regimeDependency: 'low',
+    };
+
+    hoisted.mockRunStrategyAgent.mockResolvedValueOnce(strategy);
+    hoisted.mockRunCriticAgent.mockResolvedValueOnce(critic);
+
+    await runStrategyResearch({ theme: 'quality growth', tickers: ['005930', '000660'] });
+
+    const expectedTheme = 'quality growth\n대상 종목: 005930, 000660';
+    expect(hoisted.mockRunStrategyAgent).toHaveBeenCalledWith(
+      expect.any(String),
+      { theme: expectedTheme },
+      expect.anything(),
+      expect.anything(),
+      undefined,
+    );
+    expect(hoisted.mockRunCriticAgent).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        additionalArtifacts: expect.objectContaining({
+          theme: expectedTheme,
+        }),
+      }),
+      expect.anything(),
+      expect.anything(),
+      undefined,
+    );
+  });
+
   it('equity 분석도 revise/keep 루프로 개선한다', async () => {
     const baseStrategy = {
       name: '종목 전략',

--- a/tests/workflow/runScenarioAnalysis.test.ts
+++ b/tests/workflow/runScenarioAnalysis.test.ts
@@ -1,0 +1,96 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  runScenarioAgent: vi.fn(),
+  runFundamentalAgent: vi.fn(),
+  runNewsAgent: vi.fn(),
+  runScenarioCriticAgent: vi.fn(),
+}));
+
+vi.mock('../../src/agents/scenarioAgent.js', () => ({
+  runScenarioAgent: mocks.runScenarioAgent,
+}));
+
+vi.mock('../../src/agents/fundamentalAgent.js', () => ({
+  runFundamentalAgent: mocks.runFundamentalAgent,
+}));
+
+vi.mock('../../src/agents/newsAgent.js', () => ({
+  runNewsAgent: mocks.runNewsAgent,
+}));
+
+vi.mock('../../src/agents/criticAgent.js', () => ({
+  runScenarioCriticAgent: mocks.runScenarioCriticAgent,
+}));
+
+import { runScenarioAnalysis } from '../../src/workflow/runScenarioAnalysis.js';
+
+describe('runScenarioAnalysis', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.runScenarioAgent.mockResolvedValue({
+      name: 'Rate Cut',
+      affectedTickers: ['005930', '000660'],
+      assumptions: [],
+    });
+    mocks.runFundamentalAgent.mockImplementation(async (_runId, input) => ({
+      ticker: input.ticker,
+      metrics: {},
+    }));
+    mocks.runNewsAgent.mockImplementation(async (_runId, input) => ({
+      ticker: input.ticker,
+      catalysts: [],
+    }));
+    mocks.runScenarioCriticAgent.mockResolvedValue({
+      scenarioName: 'Rate Cut',
+      projections: [],
+      overallAssessment: 'mixed',
+      confidence: 'medium',
+      keyRisks: [],
+      recommendations: [],
+      disclaimer: '이 분석은 LLM 기반 추론이며 투자 조언이 아닙니다.',
+    });
+  });
+
+  it('일부 종목 분석 실패 시 성공한 종목만 critic에 전달한다', async () => {
+    mocks.runFundamentalAgent.mockImplementation(async (_runId, input) => {
+      if (input.ticker === '000660') throw new Error('fundamental failed');
+      return { ticker: input.ticker, metrics: {} };
+    });
+
+    const result = await runScenarioAnalysis({ scenario: 'rate cut' });
+
+    expect(result.fundamentals).toHaveLength(1);
+    expect(result.newsAnalyses).toHaveLength(1);
+    expect(mocks.runScenarioCriticAgent).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        fundamentals: [{ ticker: '005930', metrics: {} }],
+        newsAnalyses: [{ ticker: '005930', catalysts: [] }],
+      }),
+      expect.anything(),
+      expect.anything(),
+      undefined,
+    );
+  });
+
+  it('모든 종목 분석이 실패하면 에러를 던진다', async () => {
+    mocks.runFundamentalAgent.mockRejectedValue(new Error('all failed'));
+
+    await expect(runScenarioAnalysis({ scenario: 'rate cut' })).rejects.toThrow(
+      '모든 종목 분석이 실패했습니다.',
+    );
+  });
+
+  it('critic 실패 시 low-confidence fallback report를 반환한다', async () => {
+    mocks.runScenarioCriticAgent.mockRejectedValue(new Error('critic failed'));
+
+    const result = await runScenarioAnalysis({ scenario: 'rate cut' });
+
+    expect(result.report).toMatchObject({
+      scenarioName: 'Rate Cut',
+      confidence: 'low',
+      keyRisks: ['Critic 에이전트 응답 실패로 종합 평가 누락'],
+    });
+  });
+});

--- a/tests/workflow/runScreening.test.ts
+++ b/tests/workflow/runScreening.test.ts
@@ -1,0 +1,50 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  runUniverseAgent: vi.fn(),
+  runFundamentalAgent: vi.fn(),
+}));
+
+vi.mock('../../src/agents/universeAgent.js', () => ({
+  runUniverseAgent: mocks.runUniverseAgent,
+}));
+
+vi.mock('../../src/agents/fundamentalAgent.js', () => ({
+  runFundamentalAgent: mocks.runFundamentalAgent,
+}));
+
+import { runScreening } from '../../src/workflow/runScreening.js';
+import { screeningTool } from '../../src/tools/workflowTools.js';
+
+describe('runScreening', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.runUniverseAgent.mockResolvedValue({
+      tickers: Array.from({ length: 8 }, (_, index) => ({ ticker: `00000${index}` })),
+    });
+    mocks.runFundamentalAgent.mockImplementation(async (_runId, input) => ({
+      ticker: input.ticker,
+      metrics: {},
+    }));
+  });
+
+  it('topN 기본값 5개만 분석한다', async () => {
+    const result = await runScreening({ market: 'KR' });
+
+    expect(result.rankings).toHaveLength(5);
+    expect(mocks.runFundamentalAgent).toHaveBeenCalledTimes(5);
+  });
+
+  it('명시한 topN을 사용한다', async () => {
+    const result = await runScreening({ market: 'KR', topN: 2 });
+
+    expect(result.rankings.map((ranking) => ranking.ticker)).toEqual(['000000', '000001']);
+    expect(mocks.runFundamentalAgent).toHaveBeenCalledTimes(2);
+  });
+
+  it('tool schema 설명도 구현 기본값 5와 일치한다', () => {
+    const schema = JSON.parse(JSON.stringify(screeningTool.parameters));
+
+    expect(schema.properties.topN.description).toContain('기본: 5');
+  });
+});

--- a/tests/workflow/runScreening.test.ts
+++ b/tests/workflow/runScreening.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
   runUniverseAgent: vi.fn(),
@@ -17,6 +17,8 @@ import { runScreening } from '../../src/workflow/runScreening.js';
 import { screeningTool } from '../../src/tools/workflowTools.js';
 
 describe('runScreening', () => {
+  const originalMaxConcurrent = process.env.DURE_MAX_CONCURRENT_SESSIONS;
+
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.runUniverseAgent.mockResolvedValue({
@@ -26,6 +28,14 @@ describe('runScreening', () => {
       ticker: input.ticker,
       metrics: {},
     }));
+  });
+
+  afterEach(() => {
+    if (originalMaxConcurrent === undefined) {
+      delete process.env.DURE_MAX_CONCURRENT_SESSIONS;
+    } else {
+      process.env.DURE_MAX_CONCURRENT_SESSIONS = originalMaxConcurrent;
+    }
   });
 
   it('topN 기본값 5개만 분석한다', async () => {
@@ -40,6 +50,34 @@ describe('runScreening', () => {
 
     expect(result.rankings.map((ranking) => ranking.ticker)).toEqual(['000000', '000001']);
     expect(mocks.runFundamentalAgent).toHaveBeenCalledTimes(2);
+  });
+
+  it('DURE_MAX_CONCURRENT_SESSIONS로 workflow 병렬도를 제한한다', async () => {
+    process.env.DURE_MAX_CONCURRENT_SESSIONS = '1';
+    const started: string[] = [];
+    let releaseFirst: (() => void) | undefined;
+
+    mocks.runFundamentalAgent.mockImplementation(async (_runId, input) => {
+      started.push(input.ticker);
+      if (input.ticker === '000000') {
+        await new Promise<void>((resolve) => {
+          releaseFirst = resolve;
+        });
+      }
+      return { ticker: input.ticker, metrics: {} };
+    });
+
+    const screening = runScreening({ market: 'KR', topN: 2 });
+
+    await vi.waitFor(() => {
+      expect(started).toEqual(['000000']);
+    });
+    releaseFirst?.();
+
+    await expect(screening).resolves.toMatchObject({
+      rankings: [{ ticker: '000000' }, { ticker: '000001' }],
+    });
+    expect(started).toEqual(['000000', '000001']);
   });
 
   it('tool schema 설명도 구현 기본값 5와 일치한다', () => {


### PR DESCRIPTION
## Summary
- Pi 기반 agent workflow의 세션 생성 비용과 retry 설정 의존성을 줄였습니다.
- 전략 리서치, 스크리닝, 리뷰 체크리스트 흐름의 누락/불일치 지점을 보강했습니다.
- 런타임, 설정, workflow orchestration 테스트를 확장했습니다.

## Related Issue / Context
- N/A

## What Changed
- Pi runtime service와 resource loader를 process-local로 재사용하고 명시적 `SettingsManager` retry/compaction 설정을 적용했습니다.
- `DURE_MAX_CONCURRENT_SESSIONS`로 workflow 병렬도를 조정할 수 있게 하고 관련 문서를 추가했습니다.
- strategy research의 `tickers` 입력을 strategy/critic context에 반영하고 screening `topN` 설명을 구현 기본값과 맞췄습니다.
- event recorder가 retry/provider error metadata와 turn duration을 `events.json`에 남기도록 확장했습니다.
- review checklist synthesizer가 전체 evidence bundle 대신 compact source summary를 받도록 조정했습니다.
- SessionPool, createPiSession, config, screening, scenario, event recorder, strategy ticker context 테스트를 추가했습니다.

## Verification
- `npm test`
- Result: pass, 18 test files / 101 tests
- `npm run lint`
- Result: pass, Biome checked 44 files
- `npm run build`
- Result: pass, TypeScript build completed

## Breaking Changes / Migration Notes
- None