### PR TITLE
test: 커버리지 검증 강화

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
       "devDependencies": {
         "@biomejs/biome": "2.4.7",
         "@types/node": "^22.0.0",
+        "@vitest/coverage-v8": "4.1.0",
         "tsx": "^4.19.0",
         "typescript": "^5.7.0",
         "vitest": "^4.1.0"
@@ -771,6 +772,42 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
+      "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/@babel/runtime": {
       "version": "7.29.2",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
@@ -778,6 +815,30 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@biomejs/biome": {
@@ -1571,12 +1632,33 @@
         }
       }
     },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
     },
     "node_modules/@mariozechner/clipboard": {
       "version": "0.3.5",
@@ -2903,6 +2985,37 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.0.tgz",
+      "integrity": "sha512-nDWulKeik2bL2Va/Wl4x7DLuTKAXa906iRFooIRPR+huHkcvp9QDkPQ2RJdmjOFrqOqvNfoSQLF68deE3xC3CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.0",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.0",
+        "vitest": "4.1.0"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@vitest/expect": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.0.tgz",
@@ -3078,6 +3191,18 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.0.tgz",
+      "integrity": "sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
       }
     },
     "node_modules/balanced-match": {
@@ -3825,6 +3950,13 @@
         "node": "^20.17.0 || >=22.9.0"
       }
     },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
@@ -3898,6 +4030,45 @@
         "node": ">=8"
       }
     },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/jiti": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
@@ -3906,6 +4077,13 @@
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
+    },
+    "node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/json-bigint": {
       "version": "1.0.0",
@@ -4245,6 +4423,34 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.2.tgz",
+      "integrity": "sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/marked": {
@@ -4776,6 +4982,19 @@
       ],
       "license": "MIT"
     },
+    "node_modules/semver": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/siginfo": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
@@ -4851,6 +5070,13 @@
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
       "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -5278,13 +5504,6 @@
           "optional": false
         }
       }
-    },
-    "node_modules/vitest/node_modules/std-env": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.0.0.tgz",
-      "integrity": "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/web-streams-polyfill": {
       "version": "3.3.3",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "lint:fix": "biome check --write .",
     "format": "biome format --write .",
     "test": "vitest run",
+    "test:coverage": "vitest run --config ./vitest.config.ts --coverage",
     "test:watch": "vitest"
   },
   "dependencies": {
@@ -24,6 +25,7 @@
   "devDependencies": {
     "@biomejs/biome": "2.4.7",
     "@types/node": "^22.0.0",
+    "@vitest/coverage-v8": "4.1.0",
     "tsx": "^4.19.0",
     "typescript": "^5.7.0",
     "vitest": "^4.1.0"

--- a/tests/agents/orchestration.test.ts
+++ b/tests/agents/orchestration.test.ts
@@ -1,0 +1,357 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ArtifactStore } from '../../src/runtime/artifactStore.js';
+import type { EventRecorder } from '../../src/runtime/eventRecorder.js';
+
+const mocks = vi.hoisted(() => ({
+  createPiSession: vi.fn(),
+  getToolsForAgent: vi.fn(),
+}));
+
+vi.mock('../../src/runtime/createPiSession.js', () => ({
+  createPiSession: mocks.createPiSession,
+}));
+
+vi.mock('../../src/cli/agent-tools.js', () => ({
+  getToolsForAgent: mocks.getToolsForAgent,
+}));
+
+import { runCriticAgent, runScenarioCriticAgent } from '../../src/agents/criticAgent.js';
+import { runFundamentalAgent } from '../../src/agents/fundamentalAgent.js';
+import { runNewsAgent } from '../../src/agents/newsAgent.js';
+import { runScenarioAgent } from '../../src/agents/scenarioAgent.js';
+import { runStrategyAgent } from '../../src/agents/strategyAgent.js';
+import { runUniverseAgent } from '../../src/agents/universeAgent.js';
+
+interface SessionOptions {
+  agentName: string;
+  sessionLabel: string;
+  systemPrompt: string;
+  customTools?: Array<{ name?: string }>;
+  useCodeTools?: boolean;
+}
+
+interface CapturedSession {
+  options: SessionOptions;
+  prompts: string[];
+}
+
+const sessions: CapturedSession[] = [];
+let store: Pick<ArtifactStore, 'put'>;
+let recorder: EventRecorder;
+
+beforeEach(() => {
+  sessions.length = 0;
+  store = { put: vi.fn() };
+  recorder = {} as EventRecorder;
+  mocks.getToolsForAgent.mockResolvedValue([{ name: 'rpc_lookup' }]);
+  mocks.createPiSession.mockImplementation(async (options: SessionOptions) => {
+    const captured: CapturedSession = { options, prompts: [] };
+    const session = {
+      state: {
+        messages: [] as Array<{ role: string; content: string }>,
+      },
+      prompt: vi.fn(async (userMessage: string) => {
+        captured.prompts.push(userMessage);
+        session.state.messages.push({
+          role: 'assistant',
+          content: JSON.stringify(responseFor(options, captured.prompts.length)),
+        });
+      }),
+    };
+
+    sessions.push(captured);
+    return session as never;
+  });
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('agent orchestration', () => {
+  it('fundamental agent는 RPC와 memory 도구를 연결하고 scenario context를 prompt에 포함한다', async () => {
+    const result = await runFundamentalAgent(
+      'run-1',
+      {
+        ticker: '005930',
+        scenarioContext: scenarioContext(),
+      },
+      store as ArtifactStore,
+      recorder,
+    );
+
+    expect(result).toMatchObject({ ticker: '005930' });
+    expect(mocks.getToolsForAgent).toHaveBeenCalledWith('fundamental');
+    expect(sessions[0]?.options).toMatchObject({
+      agentName: 'fundamental',
+      sessionLabel: 'fundamental:005930',
+    });
+    expect(sessions[0]?.options.customTools?.map((tool) => tool.name)).toEqual([
+      'rpc_lookup',
+      'memory_read',
+      'memory_search',
+    ]);
+    expect(sessions[0]?.prompts[0]).toContain('=== 시나리오 컨텍스트 ===');
+    expect(store.put).toHaveBeenCalledWith('run-1', 'fundamental', '005930', result);
+  });
+
+  it('news agent는 news_search를 맨 앞에 두고 기본 기간과 scenario context를 전달한다', async () => {
+    const result = await runNewsAgent(
+      'run-2',
+      { ticker: '000660', scenarioContext: scenarioContext() },
+      store as ArtifactStore,
+      recorder,
+    );
+
+    expect(result).toMatchObject({ ticker: '000660' });
+    expect(sessions[0]?.options.customTools?.map((tool) => tool.name).slice(0, 4)).toEqual([
+      'news_search',
+      'rpc_lookup',
+      'memory_read',
+      'memory_search',
+    ]);
+    expect(sessions[0]?.prompts[0]).toContain('기간: 최근 3개월');
+    expect(sessions[0]?.prompts[0]).toContain('위 시나리오 가정 하에서 이 종목의 뉴스/이벤트 영향을 분석하세요.');
+    expect(store.put).toHaveBeenCalledWith('run-2', 'news', '000660', result);
+  });
+
+  it('scenario agent는 tickers를 prompt에 포함하고 definition artifact를 저장한다', async () => {
+    const result = await runScenarioAgent(
+      'scenario-run-1',
+      { scenario: '50bp emergency cut', tickers: ['005930', '000660'] },
+      store as ArtifactStore,
+      recorder,
+    );
+
+    expect(result.affectedTickers).toEqual(['005930', '000660']);
+    expect(sessions[0]?.options).toMatchObject({
+      agentName: 'scenario',
+      sessionLabel: 'scenario:scenario-run-1',
+    });
+    expect(sessions[0]?.prompts[0]).toContain('분석 대상 종목: 005930, 000660');
+    expect(store.put).toHaveBeenCalledWith('scenario-run-1', 'scenario', 'definition', result);
+  });
+
+  it('universe agent는 누락된 옵션을 기본 문구로 채운다', async () => {
+    const result = await runUniverseAgent('run-3', {}, store as ArtifactStore, recorder);
+
+    expect(result.tickers[0]?.ticker).toBe('005930');
+    expect(sessions[0]?.options.sessionLabel).toBe('universe:global');
+    expect(sessions[0]?.prompts[0]).toContain('시장: 전체');
+    expect(sessions[0]?.prompts[0]).toContain('스타일: 없음');
+    expect(sessions[0]?.prompts[0]).toContain('필터규칙: 없음');
+    expect(store.put).toHaveBeenCalledWith('run-3', 'universe', 'output', result);
+  });
+
+  it('strategy agent는 evidence와 feedback을 포함하고 비영어 결과를 재요청한다', async () => {
+    const result = await runStrategyAgent(
+      'run-4',
+      {
+        theme: 'quality dividend',
+        fundamentals: [fundamentalAnalysis()],
+        newsAnalyses: [newsAnalysis()],
+        feedback: 'Add invalidation trigger.',
+      },
+      store as ArtifactStore,
+      recorder,
+    );
+
+    expect(result.name).toBe('Quality Dividend');
+    expect(sessions[0]?.options).toMatchObject({
+      agentName: 'strategy',
+      sessionLabel: 'strategy:quality dividend',
+      useCodeTools: true,
+    });
+    expect(sessions[0]?.options.customTools?.map((tool) => tool.name)).toEqual([
+      'rpc_lookup',
+      'memory_read',
+      'memory_write',
+      'memory_search',
+    ]);
+    expect(sessions[0]?.prompts).toHaveLength(2);
+    expect(sessions[0]?.prompts[0]).toContain('=== 펀더멘털 분석 ===');
+    expect(sessions[0]?.prompts[0]).toContain('=== 뉴스 분석 ===');
+    expect(sessions[0]?.prompts[0]).toContain('=== Critic 피드백 ===');
+    expect(sessions[0]?.prompts[1]).toContain('Invalid field: strategy.name');
+    expect(store.put).toHaveBeenCalledWith('run-4', 'strategy', 'output', result);
+  });
+
+  it('critic agent는 추가 분석 데이터를 포함하고 비영어 recommendations를 재요청한다', async () => {
+    const result = await runCriticAgent(
+      'run-5',
+      {
+        strategy: strategyDefinition(),
+        additionalArtifacts: {
+          stress: { maxDrawdown: -0.2 },
+        },
+      },
+      store as ArtifactStore,
+      recorder,
+    );
+
+    expect(result.verdict).toBe('revise');
+    expect(sessions[0]?.options.customTools?.map((tool) => tool.name)).toEqual([
+      'memory_read',
+      'memory_write',
+      'memory_search',
+    ]);
+    expect(sessions[0]?.prompts).toHaveLength(2);
+    expect(sessions[0]?.prompts[0]).toContain('=== 추가 분석 데이터 ===');
+    expect(sessions[0]?.prompts[0]).toContain('--- stress ---');
+    expect(sessions[0]?.prompts[1]).toContain('Invalid field: critic.recommendations[0]');
+    expect(store.put).toHaveBeenCalledWith('run-5', 'critic', 'output', result);
+  });
+
+  it('scenario critic agent는 fundamentals/news를 종합해 scenario-critic artifact를 저장한다', async () => {
+    const result = await runScenarioCriticAgent(
+      'run-6',
+      {
+        scenarioContext: scenarioContext(),
+        fundamentals: [fundamentalAnalysis()],
+        newsAnalyses: [newsAnalysis()],
+      },
+      store as ArtifactStore,
+      recorder,
+    );
+
+    expect(result.scenarioName).toBe('Rate cut');
+    expect(sessions[0]?.options.sessionLabel).toBe('critic:scenario:Rate cut');
+    expect(sessions[0]?.prompts[0]).toContain('=== 펀더멘털 분석 ===');
+    expect(sessions[0]?.prompts[0]).toContain('=== 뉴스 분석 ===');
+    expect(store.put).toHaveBeenCalledWith('run-6', 'scenario-critic', 'output', result);
+  });
+});
+
+function responseFor(options: SessionOptions, promptCount: number): unknown {
+  if (options.agentName === 'fundamental') return fundamentalAnalysis();
+  if (options.agentName === 'news') {
+    const ticker = options.sessionLabel.replace('news:', '');
+    return { ...newsAnalysis(), ticker };
+  }
+  if (options.agentName === 'scenario') return scenarioContext();
+  if (options.agentName === 'universe') {
+    return {
+      tickers: [
+        {
+          ticker: '005930',
+          market: 'KR',
+          sector: 'Technology',
+          rationale: 'Quality screen match',
+        },
+      ],
+      filterCriteria: 'quality',
+    };
+  }
+  if (options.agentName === 'strategy' && promptCount === 1) {
+    return { ...strategyDefinition(), name: '품질 배당' };
+  }
+  if (options.agentName === 'strategy') return strategyDefinition();
+  if (options.sessionLabel.startsWith('critic:scenario:')) return scenarioReport();
+  if (options.agentName === 'critic' && promptCount === 1) {
+    return { ...criticReport(), recommendations: ['리스크 한도를 추가하세요'] };
+  }
+  if (options.agentName === 'critic' && promptCount === 2) return criticReport();
+  return scenarioReport();
+}
+
+function strategyDefinition() {
+  return {
+    name: 'Quality Dividend',
+    hypothesis: 'Durable cash returns outperform in volatile regimes.',
+    entryRules: ['Buy when ROE and dividend coverage are stable.'],
+    exitRules: ['Exit when payout is debt funded.'],
+    positionSizing: 'Equal weight with sector caps',
+    rebalancePeriod: 'Quarterly',
+    config: { minRoe: 15 },
+  };
+}
+
+function criticReport() {
+  return {
+    overfittingRisk: 'Medium because factors are few.',
+    dataLeakageCheck: 'No forward-looking metrics included.',
+    survivorshipBias: 'Needs delisted-company check.',
+    regimeDependency: 'Works best in defensive regimes.',
+    verdict: 'revise' as const,
+    recommendations: ['Add explicit drawdown stop.'],
+  };
+}
+
+function scenarioContext() {
+  return {
+    name: 'Rate cut',
+    description: 'Central bank cuts policy rates by 50bp.',
+    variables: [
+      {
+        name: 'Policy rate',
+        baseline: '5.00%',
+        scenario: '4.50%',
+        direction: 'down' as const,
+      },
+    ],
+    affectedTickers: ['005930', '000660'],
+    timeHorizon: '3 months',
+    assumptions: ['Inflation remains contained.'],
+  };
+}
+
+function fundamentalAnalysis() {
+  return {
+    ticker: '005930',
+    metrics: {
+      revenue: 100,
+      operatingMargin: 20,
+      netMargin: 15,
+      PE: 12,
+      PB: 1.2,
+      ROE: 16,
+      debtToEquity: 30,
+    },
+    growthTrend: 'Improving',
+    quarterlyChanges: 'Margins expanded sequentially.',
+    redFlags: ['Memory pricing volatility'],
+    memo: 'HBM mix supports margin.',
+  };
+}
+
+function newsAnalysis() {
+  return {
+    ticker: '005930',
+    eventTimeline: [
+      {
+        date: '2026-01-01',
+        headline: 'HBM supply agreement expanded',
+        impact: 'positive',
+      },
+    ],
+    sentimentSummary: 'Positive',
+    catalysts: ['AI server demand'],
+    risks: ['Memory downcycle'],
+  };
+}
+
+function scenarioReport() {
+  return {
+    scenarioName: 'Rate cut',
+    projections: [
+      {
+        ticker: '005930',
+        fundamentalImpact: {
+          direction: 'positive' as const,
+          magnitude: 'medium' as const,
+          rationale: 'Lower discount rates support valuation.',
+          affectedMetrics: ['PE'],
+        },
+        newsContext: {
+          expectedSentiment: 'bullish' as const,
+          likelyCatalysts: ['FOMC decision'],
+        },
+      },
+    ],
+    overallAssessment: 'Moderately positive for quality technology exporters.',
+    confidence: 'medium' as const,
+    keyRisks: ['Inflation rebound'],
+    recommendations: ['Monitor rate path.'],
+    disclaimer: 'This analysis is LLM-based reasoning and not investment advice.',
+  };
+}

--- a/tests/memory/repos.test.ts
+++ b/tests/memory/repos.test.ts
@@ -1,0 +1,179 @@
+import { mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { StoredStrategy } from '../../src/memory/strategyRepo.js';
+import type { Thesis } from '../../src/memory/thesisRepo.js';
+import type { ExperimentRecord } from '../../src/schemas/signal.js';
+
+const originalCwd = process.cwd();
+let tmpDir: string;
+
+beforeEach(async () => {
+  tmpDir = path.join(os.tmpdir(), `repo-test-${Date.now()}-${Math.random()}`);
+  await mkdir(tmpDir, { recursive: true });
+  process.chdir(tmpDir);
+  vi.resetModules();
+});
+
+afterEach(async () => {
+  process.chdir(originalCwd);
+  await rm(tmpDir, { recursive: true, force: true });
+  vi.restoreAllMocks();
+});
+
+describe('StrategyRepo', () => {
+  it('파일이 없으면 빈 목록으로 시작하고 add 결과를 디스크에 저장한다', async () => {
+    const { StrategyRepo } = await import('../../src/memory/strategyRepo.js');
+    const repo = new StrategyRepo();
+    const record = strategyRecord('strategy-1');
+
+    expect(await repo.list()).toEqual([]);
+
+    await repo.add(record);
+
+    expect(await repo.get('strategy-1')).toEqual(record);
+    await expect(readJson('data/processed/strategies.json')).resolves.toEqual([record]);
+  });
+
+  it('기존 JSON을 로드하고 update는 updatedAt을 새로 기록한다', async () => {
+    const existing = strategyRecord('strategy-1', '2026-01-01T00:00:00.000Z');
+    await writeJson('data/processed/strategies.json', [existing]);
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-02-03T04:05:06.000Z'));
+
+    const { StrategyRepo } = await import('../../src/memory/strategyRepo.js');
+    const repo = new StrategyRepo();
+
+    await repo.update('strategy-1', { iterationCount: 3, lastCriticVerdict: 'keep' });
+
+    expect(await repo.get('strategy-1')).toMatchObject({
+      id: 'strategy-1',
+      iterationCount: 3,
+      lastCriticVerdict: 'keep',
+      updatedAt: '2026-02-03T04:05:06.000Z',
+    });
+    await expect(readJson('data/processed/strategies.json')).resolves.toMatchObject([
+      { id: 'strategy-1', iterationCount: 3 },
+    ]);
+  });
+
+  it('없는 id update는 파일을 다시 쓰지 않는다', async () => {
+    const existing = strategyRecord('strategy-1');
+    await writeJson('data/processed/strategies.json', [existing]);
+    const { StrategyRepo } = await import('../../src/memory/strategyRepo.js');
+    const repo = new StrategyRepo();
+
+    await repo.update('missing', { iterationCount: 9 });
+
+    expect(await repo.list()).toEqual([existing]);
+    await expect(readJson('data/processed/strategies.json')).resolves.toEqual([existing]);
+  });
+});
+
+describe('ThesisRepo', () => {
+  it('thesis를 저장하고 status 업데이트 시 updatedAt을 갱신한다', async () => {
+    const { ThesisRepo } = await import('../../src/memory/thesisRepo.js');
+    const repo = new ThesisRepo();
+    const thesis = thesisRecord('thesis-1', 'active', '2026-01-01T00:00:00.000Z');
+
+    await repo.add(thesis);
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-02-03T04:05:06.000Z'));
+    await repo.update('thesis-1', { status: 'confirmed', evidence: ['filing', 'call'] });
+
+    expect(await repo.get('thesis-1')).toMatchObject({
+      id: 'thesis-1',
+      status: 'confirmed',
+      evidence: ['filing', 'call'],
+      updatedAt: '2026-02-03T04:05:06.000Z',
+    });
+    await expect(readJson('data/processed/theses.json')).resolves.toMatchObject([
+      { id: 'thesis-1', status: 'confirmed' },
+    ]);
+  });
+});
+
+describe('ExperimentRepo', () => {
+  it('실험 기록을 저장하고 결과 patch를 병합한다', async () => {
+    const { ExperimentRepo } = await import('../../src/memory/experimentRepo.js');
+    const repo = new ExperimentRepo();
+    const experiment = experimentRecord('experiment-1');
+
+    await repo.add(experiment);
+    await repo.update('experiment-1', {
+      criticVerdict: 'keep',
+      result: { sharpe: 1.3, maxDrawdown: -0.08 },
+    });
+
+    expect(await repo.get('experiment-1')).toMatchObject({
+      id: 'experiment-1',
+      criticVerdict: 'keep',
+      result: { sharpe: 1.3, maxDrawdown: -0.08 },
+    });
+    await expect(readJson('data/processed/experiments.json')).resolves.toMatchObject([
+      { id: 'experiment-1', criticVerdict: 'keep' },
+    ]);
+  });
+
+  it('손상된 JSON은 빈 저장소처럼 처리한다', async () => {
+    await mkdir('data/processed', { recursive: true });
+    await writeFile('data/processed/experiments.json', '{broken json', 'utf-8');
+
+    const { ExperimentRepo } = await import('../../src/memory/experimentRepo.js');
+    const repo = new ExperimentRepo();
+
+    expect(await repo.list()).toEqual([]);
+  });
+});
+
+async function writeJson(relativePath: string, data: unknown): Promise<void> {
+  await mkdir(path.dirname(relativePath), { recursive: true });
+  await writeFile(relativePath, JSON.stringify(data, null, 2), 'utf-8');
+}
+
+async function readJson(relativePath: string): Promise<unknown> {
+  return JSON.parse(await readFile(relativePath, 'utf-8'));
+}
+
+function strategyRecord(id: string, updatedAt = '2026-01-02T00:00:00.000Z'): StoredStrategy {
+  return {
+    id,
+    strategy: {
+      name: 'Quality Growth',
+      hypothesis: 'High quality companies compound through cycles.',
+      entryRules: ['Buy when ROE is stable.'],
+      exitRules: ['Sell when debt rises sharply.'],
+      positionSizing: 'Equal weight',
+      rebalancePeriod: 'Quarterly',
+      config: { minRoe: 15 },
+    },
+    lastCriticVerdict: 'revise',
+    iterationCount: 1,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt,
+  };
+}
+
+function thesisRecord(id: string, status: Thesis['status'], updatedAt: string): Thesis {
+  return {
+    id,
+    ticker: '005930',
+    hypothesis: 'HBM demand supports margins.',
+    evidence: ['customer order'],
+    status,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt,
+  };
+}
+
+function experimentRecord(id: string): ExperimentRecord {
+  return {
+    id,
+    strategyId: 'strategy-1',
+    params: { lookback: 12 },
+    result: { sharpe: 0.8 },
+    criticVerdict: 'revise',
+    timestamp: '2026-01-01T00:00:00.000Z',
+  };
+}

--- a/tests/runtime/artifactStore.test.ts
+++ b/tests/runtime/artifactStore.test.ts
@@ -1,0 +1,83 @@
+import { mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const originalCwd = process.cwd();
+let tmpDir: string;
+
+beforeEach(async () => {
+  tmpDir = path.join(os.tmpdir(), `artifact-store-test-${Date.now()}-${Math.random()}`);
+  await mkdir(tmpDir, { recursive: true });
+  process.chdir(tmpDir);
+  vi.resetModules();
+});
+
+afterEach(async () => {
+  process.chdir(originalCwd);
+  await rm(tmpDir, { recursive: true, force: true });
+  vi.restoreAllMocks();
+});
+
+describe('ArtifactStore', () => {
+  it('put은 캐시와 data/runs JSON 파일을 함께 갱신한다', async () => {
+    const { ArtifactStore } = await import('../../src/runtime/artifactStore.js');
+    const store = new ArtifactStore();
+    const artifact = { ticker: '005930', memo: 'quality compounder' };
+
+    await store.put('run-1', 'fundamental', '005930', artifact);
+
+    await expect(store.get('run-1', 'fundamental', '005930')).resolves.toEqual(artifact);
+    await expect(readJson('data/runs/run-1/fundamental/005930.json')).resolves.toEqual(artifact);
+  });
+
+  it('get은 캐시가 없으면 디스크에서 읽고 이후 캐시된 값을 반환한다', async () => {
+    const { ArtifactStore } = await import('../../src/runtime/artifactStore.js');
+    const store = new ArtifactStore();
+    const filePath = 'data/runs/run-2/news/005930.json';
+    await writeJson(filePath, { ticker: '005930', catalysts: ['HBM'] });
+
+    await expect(store.get('run-2', 'news', '005930')).resolves.toEqual({
+      ticker: '005930',
+      catalysts: ['HBM'],
+    });
+
+    await writeFile(filePath, JSON.stringify({ ticker: '005930', catalysts: ['changed'] }));
+    await expect(store.get('run-2', 'news', '005930')).resolves.toEqual({
+      ticker: '005930',
+      catalysts: ['HBM'],
+    });
+  });
+
+  it('없는 artifact와 손상된 JSON은 undefined로 반환한다', async () => {
+    const { ArtifactStore } = await import('../../src/runtime/artifactStore.js');
+    const store = new ArtifactStore();
+    await mkdir('data/runs/run-3/critic', { recursive: true });
+    await writeFile('data/runs/run-3/critic/output.json', '{broken', 'utf-8');
+
+    await expect(store.get('run-3', 'strategy', 'output')).resolves.toBeUndefined();
+    await expect(store.get('run-3', 'critic', 'output')).resolves.toBeUndefined();
+  });
+
+  it('getRunArtifacts는 해당 run의 캐시 항목만 반환한다', async () => {
+    const { ArtifactStore } = await import('../../src/runtime/artifactStore.js');
+    const store = new ArtifactStore();
+
+    await store.put('run-4', 'strategy', 'output', { name: 'Quality' });
+    await store.put('other-run', 'strategy', 'output', { name: 'Other' });
+
+    const artifacts = await store.getRunArtifacts('run-4');
+
+    expect([...artifacts.keys()]).toEqual(['run-4/strategy/output']);
+    expect(artifacts.get('run-4/strategy/output')).toEqual({ name: 'Quality' });
+  });
+});
+
+async function writeJson(relativePath: string, data: unknown): Promise<void> {
+  await mkdir(path.dirname(relativePath), { recursive: true });
+  await writeFile(relativePath, JSON.stringify(data, null, 2), 'utf-8');
+}
+
+async function readJson(relativePath: string): Promise<unknown> {
+  return JSON.parse(await readFile(relativePath, 'utf-8'));
+}

--- a/tests/tools/memoryTools.test.ts
+++ b/tests/tools/memoryTools.test.ts
@@ -1,0 +1,83 @@
+import type { ToolDefinition } from '@earendil-works/pi-coding-agent';
+import { mkdir, rm } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const originalCwd = process.cwd();
+let tmpDir: string;
+
+beforeEach(async () => {
+  tmpDir = path.join(os.tmpdir(), `memory-tools-test-${Date.now()}-${Math.random()}`);
+  await mkdir(tmpDir, { recursive: true });
+  process.chdir(tmpDir);
+  vi.resetModules();
+});
+
+afterEach(async () => {
+  process.chdir(originalCwd);
+  await rm(tmpDir, { recursive: true, force: true });
+});
+
+describe('getMemoryTools', () => {
+  it('strategy와 critic에게만 write 도구를 제공한다', async () => {
+    const { getMemoryTools } = await import('../../src/tools/memoryTools.js');
+
+    expect(getMemoryTools('strategy').map((tool) => tool.name)).toEqual([
+      'memory_read',
+      'memory_write',
+      'memory_search',
+    ]);
+    expect(getMemoryTools('critic').map((tool) => tool.name)).toContain('memory_write');
+    expect(getMemoryTools('fundamental').map((tool) => tool.name)).toEqual([
+      'memory_read',
+      'memory_search',
+    ]);
+  });
+
+  it('write 후 topic과 index를 읽고 검색할 수 있다', async () => {
+    const { getMemoryTools } = await import('../../src/tools/memoryTools.js');
+    const tools = getMemoryTools('strategy');
+    const write = findTool(tools, 'memory_write');
+    const read = findTool(tools, 'memory_read');
+    const search = findTool(tools, 'memory_search');
+
+    await executeText(write, {
+      topic: 'strategy_patterns',
+      content: 'ROE deterioration before price weakness is a warning sign.',
+    });
+
+    await expect(executeText(read, { topic: 'index' })).resolves.toContain(
+      'strategy_patterns.md',
+    );
+    await expect(executeText(read, { topic: 'strategy_patterns' })).resolves.toContain(
+      'ROE deterioration',
+    );
+    await expect(executeText(search, { query: 'warning sign' })).resolves.toContain(
+      '## strategy_patterns',
+    );
+  });
+
+  it('없는 topic과 검색 결과 없음 메시지를 명확히 반환한다', async () => {
+    const { getMemoryTools } = await import('../../src/tools/memoryTools.js');
+    const tools = getMemoryTools('fundamental');
+
+    await expect(executeText(findTool(tools, 'memory_read'), { topic: 'missing' })).resolves.toBe(
+      "(토픽 'missing'을 찾을 수 없습니다)",
+    );
+    await expect(executeText(findTool(tools, 'memory_search'), { query: 'absent' })).resolves.toBe(
+      "'absent'에 대한 메모리 없음",
+    );
+  });
+});
+
+function findTool(tools: ToolDefinition[], name: string): ToolDefinition {
+  const tool = tools.find((candidate) => candidate.name === name);
+  if (!tool) throw new Error(`missing tool: ${name}`);
+  return tool;
+}
+
+async function executeText(tool: ToolDefinition, params: unknown): Promise<string> {
+  const result = await tool.execute('tool-call', params as never, undefined, undefined, {} as never);
+  return result.content[0].text;
+}

--- a/tests/tools/newsTool.test.ts
+++ b/tests/tools/newsTool.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import { newsTool } from '../../src/tools/newsTool.js';
+
+describe('newsTool', () => {
+  it('ticker와 limit을 적용해 최신 mock 뉴스를 제한한다', async () => {
+    const result = await newsTool.execute(
+      'tool-1',
+      { query: 'HBM', ticker: '005930', limit: 2 },
+      undefined,
+      undefined,
+      {} as never,
+    );
+    const payload = JSON.parse(result.content[0].text);
+
+    expect(payload.ticker).toBe('005930');
+    expect(payload.articles).toHaveLength(2);
+    expect(payload.articles[0]).toMatchObject({
+      headline: expect.stringContaining('HBM4'),
+      sentiment: 'positive',
+    });
+  });
+
+  it('ticker가 없으면 기본 mock ticker를 사용한다', async () => {
+    const result = await newsTool.execute(
+      'tool-2',
+      { query: 'memory cycle' },
+      undefined,
+      undefined,
+      {} as never,
+    );
+    const payload = JSON.parse(result.content[0].text);
+
+    expect(payload.ticker).toBe('000660');
+    expect(payload.articles.length).toBeGreaterThan(0);
+  });
+
+  it('지원하지 않는 ticker는 error payload로 반환한다', async () => {
+    const result = await newsTool.execute(
+      'tool-3',
+      { query: 'unknown', ticker: '999999' },
+      undefined,
+      undefined,
+      {} as never,
+    );
+
+    expect(JSON.parse(result.content[0].text)).toEqual({
+      error: '뉴스를 찾을 수 없습니다.',
+    });
+  });
+});

--- a/tests/tools/workflowTools.test.ts
+++ b/tests/tools/workflowTools.test.ts
@@ -1,0 +1,128 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  runEquityAnalysis: vi.fn(),
+  runScreening: vi.fn(),
+  runStrategyResearch: vi.fn(),
+  runScenarioAnalysis: vi.fn(),
+}));
+
+vi.mock('../../src/workflow/runEquityAnalysis.js', () => ({
+  runEquityAnalysis: mocks.runEquityAnalysis,
+}));
+
+vi.mock('../../src/workflow/runScreening.js', () => ({
+  runScreening: mocks.runScreening,
+}));
+
+vi.mock('../../src/workflow/runStrategyResearch.js', () => ({
+  runStrategyResearch: mocks.runStrategyResearch,
+}));
+
+vi.mock('../../src/workflow/runScenarioAnalysis.js', () => ({
+  runScenarioAnalysis: mocks.runScenarioAnalysis,
+}));
+
+import {
+  equityAnalysisTool,
+  scenarioAnalysisTool,
+  screeningTool,
+  strategyResearchTool,
+  workflowTools,
+} from '../../src/tools/workflowTools.js';
+
+describe('workflowTools', () => {
+  beforeEach(() => {
+    mocks.runEquityAnalysis.mockResolvedValue({ runId: 'equity-1', tickers: ['005930'] });
+    mocks.runScreening.mockResolvedValue({ runId: 'screen-1', rankings: [{ ticker: '005930' }] });
+    mocks.runStrategyResearch.mockResolvedValue({
+      runId: 'strategy-1',
+      finalStrategy: { name: 'Quality' },
+    });
+    mocks.runScenarioAnalysis.mockResolvedValue({
+      runId: 'scenario-1',
+      report: { scenarioName: 'rate cut' },
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('일반 workflow 도구 목록은 핵심 네 가지 실행 도구만 노출한다', () => {
+    expect(workflowTools.map((tool) => tool.name)).toEqual([
+      'run_equity_analysis',
+      'run_screening',
+      'run_strategy_research',
+      'run_scenario_analysis',
+    ]);
+  });
+
+  it('run_equity_analysis는 입력과 onUpdate를 workflow에 전달하고 JSON 결과를 반환한다', async () => {
+    const onUpdate = vi.fn();
+
+    const result = await equityAnalysisTool.execute(
+      'tool-1',
+      { ticker: '005930', style: 'quality' },
+      undefined,
+      onUpdate,
+      {} as never,
+    );
+
+    expect(mocks.runEquityAnalysis).toHaveBeenCalledWith(
+      { ticker: '005930', style: 'quality' },
+      onUpdate,
+    );
+    expect(JSON.parse(result.content[0].text)).toEqual({
+      runId: 'equity-1',
+      tickers: ['005930'],
+    });
+    expect(result.details?.kind).toBe('workflow-log');
+  });
+
+  it('screening, strategy, scenario 도구는 각 workflow 결과를 JSON으로 감싼다', async () => {
+    await expect(
+      screeningTool.execute('tool-2', { market: 'KR', topN: 1 }, undefined, undefined, {} as never),
+    ).resolves.toMatchObject({
+      content: [{ text: JSON.stringify({ runId: 'screen-1', rankings: [{ ticker: '005930' }] }) }],
+    });
+
+    await expect(
+      strategyResearchTool.execute(
+        'tool-3',
+        { theme: 'quality', tickers: ['005930'] },
+        undefined,
+        undefined,
+        {} as never,
+      ),
+    ).resolves.toMatchObject({
+      content: [{ text: JSON.stringify({ runId: 'strategy-1', finalStrategy: { name: 'Quality' } }) }],
+    });
+
+    await expect(
+      scenarioAnalysisTool.execute(
+        'tool-4',
+        { scenario: 'rate cut', tickers: ['005930'] },
+        undefined,
+        undefined,
+        {} as never,
+      ),
+    ).resolves.toMatchObject({
+      content: [{ text: JSON.stringify({ runId: 'scenario-1', report: { scenarioName: 'rate cut' } }) }],
+    });
+  });
+
+  it('workflow 실행 오류는 숨기지 않고 호출자에게 전파한다', async () => {
+    mocks.runScenarioAnalysis.mockRejectedValueOnce(new Error('scenario failed'));
+
+    await expect(
+      scenarioAnalysisTool.execute(
+        'tool-5',
+        { scenario: 'stress' },
+        undefined,
+        undefined,
+        {} as never,
+      ),
+    ).rejects.toThrow('scenario failed');
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['tests/**/*.test.ts'],
+    exclude: ['tests/**/*.integration.test.ts'],
+    coverage: {
+      provider: 'v8',
+      include: ['src/**/*.ts'],
+      all: true,
+      reporter: ['text'],
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- `npm run test:coverage` 기준 전체 커버리지를 80% 이상으로 끌어올렸습니다.
- 저장소, 도구, 에이전트 실행 흐름의 실제 변경 감지 테스트를 증분으로 추가했습니다.

## Related Issue / Context
- N/A

## What Changed
- Vitest V8 coverage 설정과 `test:coverage` 스크립트를 추가했습니다.
- `StrategyRepo`, `ThesisRepo`, `ExperimentRepo`, `ArtifactStore`의 저장/로드/업데이트 동작을 검증했습니다.
- memory/news/workflow tool의 실행 계약과 에러 전파를 검증했습니다.
- 주요 agent orchestration의 prompt 구성, tool 연결, artifact 저장, validation retry 경로를 검증했습니다.

## Verification
- `npm run test:coverage`
- Result: pass, 24 files / 129 tests, statements 82.53%, lines 83.61%
- `npm run lint`
- Result: pass, Biome check completed with no fixes
- `npm test`
- Result: pass, 24 files / 129 tests

## Breaking Changes / Migration Notes
- None