### PR TITLE
feat: 브라우저 뉴스 검색 추가

### DIFF
--- a/.pi/extensions/dure-browser/index.ts
+++ b/.pi/extensions/dure-browser/index.ts
@@ -1,0 +1,133 @@
+import type { ToolDefinition } from '@earendil-works/pi-coding-agent';
+import { type Static, Type } from '@sinclair/typebox';
+import {
+  AgentBrowserClient,
+  type AgentBrowserCommand,
+  type AgentBrowserRunner,
+  type AgentBrowserRunnerOptions,
+} from '../../../src/browser/agentBrowser.js';
+import { saveBrowserTextArtifact } from '../../../src/runtime/browserArtifacts.js';
+import { toolResult } from '../../../src/tools/_helpers.js';
+import { createBrowserNewsSearchTool } from '../../../src/tools/browserNewsTool.js';
+
+type PiExecResult = {
+  stdout?: string;
+  stderr?: string;
+  exitCode?: number;
+};
+
+type PiApi = {
+  exec?: (
+    command: string,
+    args: string[],
+    options?: { timeoutMs?: number; signal?: AbortSignal },
+  ) => Promise<PiExecResult>;
+  registerTool: (tool: ToolDefinition) => void;
+};
+
+const captureEvidenceParams = Type.Object({
+  url: Type.String({ description: '브라우저로 확인할 URL' }),
+  instruction: Type.Optional(
+    Type.String({ description: 'URL에서 확인할 증거 또는 추출할 메타데이터 설명' }),
+  ),
+  runId: Type.Optional(Type.String({ description: 'evidence artifact를 저장할 run ID' })),
+  ticker: Type.Optional(Type.String({ description: '관련 종목 코드' })),
+});
+
+type CaptureEvidenceParams = Static<typeof captureEvidenceParams>;
+
+export function createDureBrowserTools(pi: PiApi): ToolDefinition[] {
+  const client = new AgentBrowserClient({ runner: createPiAgentBrowserRunner(pi) });
+  return [
+    createBrowserDoctorTool(client),
+    createBrowserNewsSearchTool({ client }) as ToolDefinition,
+    createBrowserCaptureEvidenceTool(client),
+  ];
+}
+
+export default function dureBrowserExtension(pi: PiApi): void {
+  for (const tool of createDureBrowserTools(pi)) {
+    pi.registerTool(tool);
+  }
+}
+
+function createBrowserDoctorTool(client: AgentBrowserClient): ToolDefinition {
+  const parameters = Type.Object({});
+  return {
+    name: 'browser_doctor',
+    label: 'Agent Browser Doctor',
+    description:
+      'agent-browser CLI 사용 가능 여부를 확인합니다. 미설치 상태여도 Dure 시작은 실패하지 않고 안내를 반환합니다.',
+    parameters,
+    async execute(_toolCallId, _params, signal) {
+      return toolResult(JSON.stringify(await client.doctor(signal)));
+    },
+  } satisfies ToolDefinition<typeof parameters>;
+}
+
+function createBrowserCaptureEvidenceTool(client: AgentBrowserClient): ToolDefinition {
+  return {
+    name: 'browser_capture_evidence',
+    label: '브라우저 증거 캡처',
+    description:
+      'agent-browser로 URL을 열어 사용자가 지정한 증거나 메타데이터를 확인하고, runId가 있으면 artifact로 저장합니다.',
+    parameters: captureEvidenceParams,
+    async execute(_toolCallId, params: CaptureEvidenceParams, signal) {
+      const browserResult = await client.runTask({
+        instruction: [
+          `Open this URL: ${params.url}`,
+          params.instruction ?? 'Capture concise evidence metadata from the page.',
+          'Return only concise JSON metadata. Do not include full article body text.',
+        ].join('\n'),
+        sessionNameSeed: `browser-evidence-${params.ticker ?? params.url}`,
+        signal,
+      });
+
+      if (!browserResult.ok) {
+        return toolResult(
+          JSON.stringify({ url: params.url, ok: false, error: browserResult.error }),
+        );
+      }
+
+      const result: { url: string; ok: true; artifactPath?: string } = {
+        url: params.url,
+        ok: true,
+      };
+      if (params.runId) {
+        const artifact = await saveBrowserTextArtifact({
+          runId: params.runId,
+          scope: 'generic',
+          fileName: 'browser-evidence.json',
+          contentType: 'application/json',
+          text: browserResult.stdout,
+        });
+        result.artifactPath = artifact.path;
+      }
+      return toolResult(JSON.stringify(result));
+    },
+  } satisfies ToolDefinition<typeof captureEvidenceParams>;
+}
+
+function createPiAgentBrowserRunner(pi: PiApi): AgentBrowserRunner {
+  return {
+    async run(
+      command: AgentBrowserCommand,
+      options: AgentBrowserRunnerOptions,
+    ): Promise<{ stdout: string; stderr: string; exitCode?: number }> {
+      if (!pi.exec) {
+        throw Object.assign(new Error('pi.exec is not available for agent-browser'), {
+          code: 'ENOENT',
+        });
+      }
+      const result = await pi.exec(command.command, command.args, {
+        timeoutMs: options.timeoutMs,
+        signal: options.signal,
+      });
+      return {
+        stdout: result.stdout ?? '',
+        stderr: result.stderr ?? '',
+        exitCode: result.exitCode ?? 0,
+      };
+    },
+  };
+}

--- a/.pi/skills/dure-browser/SKILL.md
+++ b/.pi/skills/dure-browser/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: dure-browser
+description: Use Dure browser tools for Naver stock news and concise browser-backed evidence checks.
+---
+
+# Dure Browser
+
+Use this skill when a user asks Dure to verify investment news with a browser, inspect Naver stock news topics, or capture concise page evidence.
+
+## News Source
+
+Use `browser_news_search` for Naver stock news at `https://stock.naver.com/news`.
+When a six digit Korean stock ticker is available for company-specific research, the tool uses the stock-scoped page `https://stock.naver.com/domestic/stock/{ticker}/news` first.
+When an overseas ticker such as `AAPL` is available, the tool uses the stock-scoped world news page `https://stock.naver.com/worldstock/stock/{code}.O/worldnews` first.
+
+Supported topics:
+
+- `flashnews`: 실시간 속보
+- `mainnews`: 주요뉴스
+- `ranknews`: 많이 본 뉴스
+- `worldnews`: 해외뉴스
+- `market-outlook`: 시황·전망
+- `company-analysis`: 기업·종목분석
+- `global-market`: 해외증시
+- `bond-futures`: 채권·선물
+- `disclosure-memo`: 공시·메모
+- `exchange-rate`: 환율
+- `marketNotice`: 공시정보
+- `all`: 빠른 기본 묶음
+
+Use `query`, `ticker`, or `companyName` to filter extracted article metadata. Treat those fields as filters over Naver page results, not as a separate web search engine. On stock-scoped domestic or worldstock news pages, the ticker path already scopes the company, so use `query` only for additional filtering.
+
+Use `browser_capture_evidence` for concise page metadata checks that should be stored as evidence.
+
+## Boundaries
+
+- Use `browser_news_search` for Naver stock news.
+- Keep tool responses concise: return titles, URLs, publishers, timestamps, topics, and artifact paths rather than full article bodies.

--- a/research/prompts/news.md
+++ b/research/prompts/news.md
@@ -5,14 +5,20 @@
 
 ## 사용 가능한 도구
 
-- `news_search`: 종목/주제 관련 뉴스 검색. 최근 기사 목록과 센티먼트를 반환합니다.
+- `browser_news_search`: Naver 증권 뉴스(`https://stock.naver.com/news`)를 주제별로 탐색합니다. 최신 실제 출처 확인이 필요하면 이 도구를 우선 사용하세요.
+  - 6자리 국내 종목코드가 있는 기업 뉴스 조사에서는 `https://stock.naver.com/domestic/stock/{ticker}/news` 종목별 페이지를 우선 사용합니다.
+  - `AAPL` 같은 해외 종목코드가 있는 기업 뉴스 조사에서는 `https://stock.naver.com/worldstock/stock/{code}.O/worldnews` 종목별 해외뉴스 페이지를 우선 사용합니다.
+  - 빠른 주제 탐색: `flashnews`, `mainnews`, `ranknews`, `worldnews`, `market-outlook`, `company-analysis`, `global-market`, `bond-futures`, `disclosure-memo`, `exchange-rate`, `marketNotice`, `all`
+  - `query`, `ticker`, `companyName`은 페이지 추출 결과를 필터링하는 용도입니다. 국내/해외 종목별 페이지에서는 종목코드 경로가 이미 회사를 한정하므로 `query`는 추가 필터로만 사용합니다.
+- `news_search`: 기존 종목/주제 관련 뉴스 검색. `browser_news_search`가 실패하거나 보조 확인이 필요할 때 사용합니다.
 
 ## 분석 절차
 
-1. `news_search`로 해당 종목의 최근 뉴스를 검색하세요.
-2. 시간순으로 주요 이벤트를 정리하세요.
-3. 전체 센티먼트를 요약하세요.
-4. 주가에 긍정적 촉매(catalysts)와 부정적 리스크(risks)를 분류하세요.
+1. 최신 실제 뉴스 확인이 필요하면 `browser_news_search`로 Naver 증권 뉴스의 관련 주제를 먼저 탐색하세요. 분석 대상 종목코드가 있으면 국내/해외 종목별 뉴스 페이지를 우선 사용하세요.
+2. `browser_news_search`가 실패하거나 결과가 부족하면 `news_search`로 보완하세요.
+3. 시간순으로 주요 이벤트를 정리하세요.
+4. 전체 센티먼트를 요약하세요.
+5. 주가에 긍정적 촉매(catalysts)와 부정적 리스크(risks)를 분류하세요.
 
 ## 출력 형식
 
@@ -24,13 +30,24 @@
   ],
   "sentimentSummary": "전체 뉴스 센티먼트 요약",
   "catalysts": ["촉매1", "촉매2"],
-  "risks": ["리스크1", "리스크2"]
+  "risks": ["리스크1", "리스크2"],
+  "sources": [
+    {
+      "title": "기사 제목",
+      "url": "https://...",
+      "publisher": "언론사",
+      "publishedAt": "게시 시각",
+      "topic": "company-analysis",
+      "sourceUrl": "https://stock.naver.com/news/section?tab=company-analysis"
+    }
+  ]
 }
 ```
 
 ## 제약조건
 
-- 뉴스 내용은 반드시 `news_search` 도구 결과에 기반하세요.
+- 뉴스 내용은 반드시 `browser_news_search` 또는 `news_search` 도구 결과에 기반하세요.
+- Naver 증권 뉴스에서 확인한 기사는 가능한 한 `sources`에 포함하세요.
 - 확인되지 않은 루머는 리스크로 별도 분류하세요.
 - 이벤트 타임라인은 최신순으로 정렬하세요.
 - 단기 소음과 구조적 변화 신호를 구분해 기술하세요.

--- a/research/prompts/router.md
+++ b/research/prompts/router.md
@@ -46,6 +46,7 @@
 6. 여러 도구를 순차 실행해야 할 경우 사용자에게 계획을 설명합니다.
 7. 사용자가 리뷰 체크리스트를 요청했는데 `runId`가 없으면, 먼저 어떤 `equity-...` run을 검토할지 물어봅니다.
 8. `run_equity_analysis`를 대화형 모드에서 호출할 때는 결과 요약에 checklist review의 최종 verdict와 핵심 blocking issue를 함께 반영합니다.
+9. 뉴스 기사는 equity/news 경로를 사용합니다. Naver 리서치/리포트 페이지 검색은 사용하지 않습니다.
 
 ## 제약
 

--- a/src/agents/newsAgent.ts
+++ b/src/agents/newsAgent.ts
@@ -5,6 +5,7 @@ import { createPiSession } from '../runtime/createPiSession.js';
 import type { EventRecorder } from '../runtime/eventRecorder.js';
 import type { NewsAnalysis } from '../schemas/analysis.js';
 import type { ScenarioDefinition } from '../schemas/scenario.js';
+import { browserNewsSearchTool } from '../tools/browserNewsTool.js';
 import { getMemoryTools } from '../tools/memoryTools.js';
 import { newsTool } from '../tools/newsTool.js';
 import { buildSessionLabel, extractJsonWithRetry, loadPrompt } from './_utils.js';
@@ -30,7 +31,12 @@ export async function runNewsAgent(
     agentName: 'news',
     sessionLabel: label,
     systemPrompt: prompt,
-    customTools: [newsTool as unknown as ToolDefinition, ...rpcTools, ...getMemoryTools('news')],
+    customTools: [
+      newsTool as unknown as ToolDefinition,
+      browserNewsSearchTool as unknown as ToolDefinition,
+      ...rpcTools,
+      ...getMemoryTools('news'),
+    ],
     eventRecorder: recorder,
     onUpdate,
   });

--- a/src/browser/agentBrowser.ts
+++ b/src/browser/agentBrowser.ts
@@ -1,0 +1,220 @@
+import { execFile } from 'node:child_process';
+
+export interface AgentBrowserCommand {
+  command: string;
+  args: string[];
+}
+
+export interface AgentBrowserRunnerOptions {
+  timeoutMs: number;
+  signal?: AbortSignal;
+}
+
+export interface AgentBrowserRunnerResult {
+  stdout: string;
+  stderr: string;
+  exitCode?: number;
+}
+
+export interface AgentBrowserRunner {
+  run(
+    command: AgentBrowserCommand,
+    options: AgentBrowserRunnerOptions,
+  ): Promise<AgentBrowserRunnerResult>;
+}
+
+export type AgentBrowserErrorCode =
+  | 'AGENT_BROWSER_NOT_INSTALLED'
+  | 'AGENT_BROWSER_DOCTOR_FAILED'
+  | 'AGENT_BROWSER_RUN_FAILED';
+
+export interface AgentBrowserError {
+  code: AgentBrowserErrorCode;
+  message: string;
+  stdout?: string;
+  stderr?: string;
+}
+
+export type AgentBrowserResult =
+  | {
+      ok: true;
+      stdout: string;
+      stderr: string;
+      sessionName?: string;
+    }
+  | {
+      ok: false;
+      error: AgentBrowserError;
+    };
+
+export interface AgentBrowserClientOptions {
+  runner?: AgentBrowserRunner;
+  bin?: string;
+  timeoutMs?: number;
+  doctorTimeoutMs?: number;
+  runDoctor?: boolean;
+}
+
+export interface AgentBrowserTaskOptions {
+  instruction: string;
+  sessionNameSeed: string;
+  timeoutMs?: number;
+  signal?: AbortSignal;
+}
+
+const DEFAULT_TIMEOUT_MS = 60_000;
+const DEFAULT_DOCTOR_TIMEOUT_MS = 10_000;
+
+export class AgentBrowserClient {
+  private readonly runner: AgentBrowserRunner;
+  private readonly bin: string;
+  private readonly timeoutMs: number;
+  private readonly doctorTimeoutMs: number;
+  private readonly runDoctor: boolean;
+  private doctorPromise?: Promise<AgentBrowserResult>;
+
+  constructor(options: AgentBrowserClientOptions = {}) {
+    this.runner = options.runner ?? createExecFileAgentBrowserRunner();
+    this.bin = options.bin ?? 'agent-browser';
+    this.timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+    this.doctorTimeoutMs = options.doctorTimeoutMs ?? DEFAULT_DOCTOR_TIMEOUT_MS;
+    this.runDoctor = options.runDoctor ?? true;
+  }
+
+  async doctor(signal?: AbortSignal): Promise<AgentBrowserResult> {
+    if (!this.doctorPromise) {
+      this.doctorPromise = this.runCommand(
+        { command: this.bin, args: ['doctor', '--json'] },
+        { timeoutMs: this.doctorTimeoutMs, signal },
+        'AGENT_BROWSER_DOCTOR_FAILED',
+      );
+    }
+    return this.doctorPromise;
+  }
+
+  async runTask(options: AgentBrowserTaskOptions): Promise<AgentBrowserResult> {
+    const sessionName = deterministicSessionName(options.sessionNameSeed);
+    if (this.runDoctor) {
+      const doctor = await this.doctor(options.signal);
+      if (!doctor.ok) return doctor;
+    }
+
+    const command = {
+      command: this.bin,
+      args: ['run', '--session', sessionName, '--output', 'json', '--prompt', options.instruction],
+    };
+    const result = await this.runCommand(
+      command,
+      { timeoutMs: options.timeoutMs ?? this.timeoutMs, signal: options.signal },
+      'AGENT_BROWSER_RUN_FAILED',
+    );
+    return result.ok ? { ...result, sessionName } : result;
+  }
+
+  private async runCommand(
+    command: AgentBrowserCommand,
+    options: AgentBrowserRunnerOptions,
+    failureCode: Exclude<AgentBrowserErrorCode, 'AGENT_BROWSER_NOT_INSTALLED'>,
+  ): Promise<AgentBrowserResult> {
+    try {
+      const result = await this.runner.run(command, options);
+      const stdout = redactBrowserOutput(result.stdout);
+      const stderr = redactBrowserOutput(result.stderr);
+      if (result.exitCode && result.exitCode !== 0) {
+        return {
+          ok: false,
+          error: {
+            code: failureCode,
+            message: `${command.command} ${command.args[0] ?? ''} failed with exit code ${result.exitCode}`,
+            stdout,
+            stderr,
+          },
+        };
+      }
+      return { ok: true, stdout, stderr };
+    } catch (error) {
+      return agentBrowserErrorFromUnknown(error, failureCode);
+    }
+  }
+}
+
+export function createExecFileAgentBrowserRunner(): AgentBrowserRunner {
+  return {
+    run(command, options) {
+      return new Promise<AgentBrowserRunnerResult>((resolve, reject) => {
+        execFile(
+          command.command,
+          command.args,
+          {
+            timeout: options.timeoutMs,
+            signal: options.signal,
+            encoding: 'utf-8',
+          },
+          (error, stdout, stderr) => {
+            if (error) {
+              reject(Object.assign(error, { stdout, stderr }));
+              return;
+            }
+            resolve({ stdout, stderr, exitCode: 0 });
+          },
+        );
+      });
+    },
+  };
+}
+
+export function deterministicSessionName(seed: string): string {
+  const normalized = seed
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9._-]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 48);
+  return `dure-${normalized || 'browser'}`;
+}
+
+export function redactBrowserOutput(value: string): string {
+  return value
+    .replace(
+      /([?&](?:access_token|api_key|apikey|authorization|cookie|session|token)=)[^&#\s]+/gi,
+      '$1[REDACTED]',
+    )
+    .replace(
+      /\b(access_token|api_key|apikey|authorization|cookie|session|token)(\s*[:=]\s*)[^&\s,;]+/gi,
+      '$1$2[REDACTED]',
+    )
+    .replace(/\bCookie:\s*[^\n\r]+/gi, 'Cookie: [REDACTED]')
+    .replace(/\bAuthorization:\s*[^\n\r]+/gi, 'Authorization: [REDACTED]');
+}
+
+function agentBrowserErrorFromUnknown(
+  error: unknown,
+  failureCode: Exclude<AgentBrowserErrorCode, 'AGENT_BROWSER_NOT_INSTALLED'>,
+): AgentBrowserResult {
+  const maybeError = error as NodeJS.ErrnoException & { stdout?: string; stderr?: string };
+  const stdout = redactBrowserOutput(maybeError.stdout ?? '');
+  const stderr = redactBrowserOutput(maybeError.stderr ?? '');
+
+  if (maybeError.code === 'ENOENT') {
+    return {
+      ok: false,
+      error: {
+        code: 'AGENT_BROWSER_NOT_INSTALLED',
+        message:
+          'agent-browser CLI is not installed or not available on PATH. Install agent-browser and retry this tool.',
+        stdout,
+        stderr,
+      },
+    };
+  }
+
+  return {
+    ok: false,
+    error: {
+      code: failureCode,
+      message: maybeError.message || 'agent-browser command failed',
+      stdout,
+      stderr,
+    },
+  };
+}

--- a/src/runtime/browserArtifacts.ts
+++ b/src/runtime/browserArtifacts.ts
@@ -1,0 +1,164 @@
+import { mkdir, readFile, stat, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+
+export type BrowserArtifactScope = 'generic' | 'news';
+export type BrowserArtifactKind = 'text' | 'binary';
+
+export interface BrowserArtifactMetadata {
+  path: string;
+  relativePath: string;
+  kind: BrowserArtifactKind;
+  contentType: string;
+  sizeBytes: number;
+  createdAt: string;
+  sourceUrl?: string;
+  label?: string;
+}
+
+export interface SaveBrowserArtifactInput {
+  runId: string;
+  scope: BrowserArtifactScope;
+  ticker?: string;
+  fileName: string;
+  contentType: string;
+  sourceUrl?: string;
+  label?: string;
+}
+
+export interface SaveBrowserTextArtifactInput extends SaveBrowserArtifactInput {
+  text: string;
+}
+
+export interface SaveBrowserBinaryArtifactInput extends SaveBrowserArtifactInput {
+  bytes: Uint8Array;
+}
+
+export interface PlannedBrowserArtifactFile {
+  path: string;
+  relativePath: string;
+}
+
+const DATA_RUNS_DIR = path.resolve('data/runs');
+
+export async function saveBrowserTextArtifact(
+  input: SaveBrowserTextArtifactInput,
+): Promise<BrowserArtifactMetadata> {
+  const filePath = resolveScopedBrowserArtifactPath(input);
+  await mkdir(path.dirname(filePath), { recursive: true });
+  await writeFile(filePath, input.text, 'utf-8');
+  return writeMetadata(input, filePath, Buffer.byteLength(input.text, 'utf-8'), 'text');
+}
+
+export async function saveBrowserBinaryArtifact(
+  input: SaveBrowserBinaryArtifactInput,
+): Promise<BrowserArtifactMetadata> {
+  const filePath = resolveScopedBrowserArtifactPath(input);
+  await mkdir(path.dirname(filePath), { recursive: true });
+  await writeFile(filePath, input.bytes);
+  return writeMetadata(input, filePath, input.bytes.byteLength, 'binary');
+}
+
+export async function planBrowserArtifactFile(
+  input: SaveBrowserArtifactInput,
+): Promise<PlannedBrowserArtifactFile> {
+  const filePath = resolveScopedBrowserArtifactPath(input);
+  await mkdir(path.dirname(filePath), { recursive: true });
+  return {
+    path: filePath,
+    relativePath: path.relative(DATA_RUNS_DIR, filePath),
+  };
+}
+
+export async function recordBrowserArtifactFile(
+  input: SaveBrowserArtifactInput,
+): Promise<BrowserArtifactMetadata> {
+  const filePath = resolveScopedBrowserArtifactPath(input);
+  const fileStat = await stat(filePath);
+  const kind =
+    input.contentType.startsWith('text/') || input.contentType === 'application/json'
+      ? 'text'
+      : 'binary';
+  return writeMetadata(input, filePath, fileStat.size, kind);
+}
+
+export async function readBrowserArtifactMetadata(
+  artifactPath: string,
+): Promise<BrowserArtifactMetadata> {
+  const raw = await readFile(metadataPathFor(artifactPath), 'utf-8');
+  return JSON.parse(raw) as BrowserArtifactMetadata;
+}
+
+export function resolveScopedBrowserArtifactPath(input: SaveBrowserArtifactInput): string {
+  const fileName = safeBrowserPathSegment(input.fileName);
+  const ticker = input.ticker ? safeBrowserPathSegment(input.ticker) : undefined;
+  const segments = scopedSegments(input.scope, ticker, fileName);
+  return resolveBrowserArtifactPath(input.runId, segments);
+}
+
+export function resolveBrowserArtifactPath(runId: string, segments: string[]): string {
+  const runRoot = browserRunRoot(runId);
+  const artifactPath = path.resolve(runRoot, ...segments);
+  assertPathInside(runRoot, artifactPath);
+  return artifactPath;
+}
+
+export function browserRunRoot(runId: string): string {
+  return path.join(DATA_RUNS_DIR, safeBrowserPathSegment(runId));
+}
+
+export function safeBrowserPathSegment(value: string): string {
+  if (value.includes('/') || value.includes('\\')) {
+    throw new Error(`Invalid browser artifact path segment: ${value}`);
+  }
+  const safe = value
+    .trim()
+    .replace(/[^A-Za-z0-9._-]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+  if (!safe || safe === '.' || safe === '..') {
+    throw new Error(`Invalid browser artifact path segment: ${value}`);
+  }
+  return safe;
+}
+
+function scopedSegments(
+  scope: BrowserArtifactScope,
+  ticker: string | undefined,
+  fileName: string,
+): string[] {
+  if (scope === 'news') {
+    return ['news', ticker ?? 'unknown', 'browser', fileName];
+  }
+  return ['browser-artifacts', fileName];
+}
+
+async function writeMetadata(
+  input: SaveBrowserArtifactInput,
+  filePath: string,
+  sizeBytes: number,
+  kind: BrowserArtifactKind,
+): Promise<BrowserArtifactMetadata> {
+  const relativePath = path.relative(DATA_RUNS_DIR, filePath);
+  const metadata: BrowserArtifactMetadata = {
+    path: filePath,
+    relativePath,
+    kind,
+    contentType: input.contentType,
+    sizeBytes,
+    createdAt: new Date().toISOString(),
+    sourceUrl: input.sourceUrl,
+    label: input.label,
+  };
+  await writeFile(metadataPathFor(filePath), JSON.stringify(metadata, null, 2), 'utf-8');
+  return metadata;
+}
+
+function metadataPathFor(filePath: string): string {
+  return `${filePath}.metadata.json`;
+}
+
+function assertPathInside(root: string, target: string): void {
+  const relative = path.relative(root, target);
+  if (relative.startsWith('..') || path.isAbsolute(relative)) {
+    throw new Error(`Browser artifact path escapes run directory: ${target}`);
+  }
+}

--- a/src/schemas/analysis.ts
+++ b/src/schemas/analysis.ts
@@ -43,5 +43,18 @@ export const NewsAnalysisSchema = Type.Object({
   sentimentSummary: Type.String(),
   catalysts: Type.Array(Type.String()),
   risks: Type.Array(Type.String()),
+  sources: Type.Optional(
+    Type.Array(
+      Type.Object({
+        title: Type.String(),
+        url: Type.String(),
+        source: Type.Optional(Type.String()),
+        publisher: Type.Optional(Type.String()),
+        publishedAt: Type.Optional(Type.String()),
+        topic: Type.Optional(Type.String()),
+        sourceUrl: Type.Optional(Type.String()),
+      }),
+    ),
+  ),
 });
 export type NewsAnalysis = Static<typeof NewsAnalysisSchema>;

--- a/src/tools/browserNewsTool.ts
+++ b/src/tools/browserNewsTool.ts
@@ -1,0 +1,401 @@
+import type { ToolDefinition } from '@earendil-works/pi-coding-agent';
+import { type Static, Type } from '@sinclair/typebox';
+import { AgentBrowserClient } from '../browser/agentBrowser.js';
+import { saveBrowserTextArtifact } from '../runtime/browserArtifacts.js';
+import { toolResult } from './_helpers.js';
+
+export const NAVER_STOCK_NEWS_BASE_URL = 'https://stock.naver.com/news';
+export const NAVER_DOMESTIC_STOCK_BASE_URL = 'https://stock.naver.com/domestic/stock';
+export const NAVER_WORLD_STOCK_BASE_URL = 'https://stock.naver.com/worldstock/stock';
+
+export const NAVER_STOCK_NEWS_TOPIC_URLS = {
+  flashnews: `${NAVER_STOCK_NEWS_BASE_URL}/flashnews`,
+  mainnews: `${NAVER_STOCK_NEWS_BASE_URL}/mainnews`,
+  ranknews: `${NAVER_STOCK_NEWS_BASE_URL}/ranknews`,
+  worldnews: `${NAVER_STOCK_NEWS_BASE_URL}/worldnews`,
+  'market-outlook': `${NAVER_STOCK_NEWS_BASE_URL}/section?tab=market-outlook`,
+  'company-analysis': `${NAVER_STOCK_NEWS_BASE_URL}/section?tab=company-analysis`,
+  'global-market': `${NAVER_STOCK_NEWS_BASE_URL}/section?tab=global-market`,
+  'bond-futures': `${NAVER_STOCK_NEWS_BASE_URL}/section?tab=bond-futures`,
+  'disclosure-memo': `${NAVER_STOCK_NEWS_BASE_URL}/section?tab=disclosure-memo`,
+  'exchange-rate': `${NAVER_STOCK_NEWS_BASE_URL}/section?tab=exchange-rate`,
+  marketNotice: `${NAVER_STOCK_NEWS_BASE_URL}/marketNotice`,
+} as const;
+
+export const NAVER_STOCK_NEWS_TOPICS = [
+  'flashnews',
+  'mainnews',
+  'ranknews',
+  'worldnews',
+  'market-outlook',
+  'company-analysis',
+  'global-market',
+  'bond-futures',
+  'disclosure-memo',
+  'exchange-rate',
+  'marketNotice',
+  'all',
+] as const;
+
+export type NaverStockNewsTopic = (typeof NAVER_STOCK_NEWS_TOPICS)[number];
+
+export interface BrowserNewsArticle {
+  title: string;
+  url: string;
+  publisher?: string;
+  publishedAt?: string;
+  summary?: string;
+  topic: Exclude<NaverStockNewsTopic, 'all'>;
+  sourceUrl: string;
+}
+
+export interface BrowserNewsSearchResult {
+  source: 'naver-stock-news';
+  topic: NaverStockNewsTopic;
+  sourceUrls: string[];
+  articles: BrowserNewsArticle[];
+  artifactPath?: string;
+  error?: unknown;
+}
+
+type RawBrowserArticle = {
+  title?: unknown;
+  headline?: unknown;
+  url?: unknown;
+  link?: unknown;
+  publisher?: unknown;
+  source?: unknown;
+  publishedAt?: unknown;
+  date?: unknown;
+  time?: unknown;
+  summary?: unknown;
+  topic?: unknown;
+  sourceUrl?: unknown;
+};
+
+const topicType = Type.Unsafe<NaverStockNewsTopic>({
+  type: 'string',
+  enum: [...NAVER_STOCK_NEWS_TOPICS],
+  description:
+    'Naver 증권 뉴스 주제. all은 빠른 기본 묶음(flashnews, company-analysis, market-outlook)을 탐색합니다.',
+});
+
+const parameters = Type.Object({
+  topic: Type.Optional(topicType),
+  query: Type.Optional(Type.String({ description: '추출 결과에서 필터링할 키워드' })),
+  ticker: Type.Optional(
+    Type.String({
+      description:
+        '관련 종목 코드. 6자리 국내 종목 코드는 국내 종목별 뉴스, 해외 종목 코드는 worldstock 뉴스 페이지와 artifact 경로에 사용',
+    }),
+  ),
+  companyName: Type.Optional(Type.String({ description: '관련 회사명. 추출 결과 필터에 사용' })),
+  limit: Type.Optional(Type.Number({ description: '최대 기사 수 (기본: 20)' })),
+  runId: Type.Optional(Type.String({ description: 'artifact를 저장할 run ID' })),
+});
+
+type Params = Static<typeof parameters>;
+
+export interface BrowserNewsToolOptions {
+  client?: AgentBrowserClient;
+}
+
+export function createBrowserNewsSearchTool(
+  options: BrowserNewsToolOptions = {},
+): ToolDefinition<typeof parameters> {
+  const client = options.client ?? new AgentBrowserClient();
+  return {
+    name: 'browser_news_search',
+    label: 'Naver 증권 뉴스 브라우저 검색',
+    description:
+      'Naver 증권 뉴스 주제별 페이지, 국내 종목별 뉴스, 해외 worldstock 종목별 뉴스 페이지를 agent-browser로 열어 최신 기사 목록을 수집합니다. 뉴스 원문 전체가 아니라 출처/링크/메타데이터를 반환합니다.',
+    parameters,
+    async execute(_toolCallId, params: Params, signal) {
+      const topic = params.topic ?? 'all';
+      const sourceUrls = getNaverStockNewsUrls(topic, { ticker: params.ticker });
+      const browserResult = await client.runTask({
+        instruction: buildNaverStockNewsInstruction({ ...params, topic, sourceUrls }),
+        sessionNameSeed: `naver-stock-news-${topic}-${params.ticker ?? params.companyName ?? params.query ?? 'latest'}`,
+        signal,
+      });
+
+      if (!browserResult.ok) {
+        return toolResult(
+          JSON.stringify({
+            source: 'naver-stock-news',
+            topic,
+            sourceUrls,
+            articles: [],
+            error: browserResult.error,
+          } satisfies BrowserNewsSearchResult),
+        );
+      }
+
+      const parsed = parseBrowserNewsStdout(browserResult.stdout);
+      const articles = normalizeBrowserNewsArticles(parsed, {
+        topic,
+        sourceUrls,
+        query: params.query,
+        ticker: params.ticker,
+        companyName: params.companyName,
+        limit: params.limit ?? 20,
+      });
+      const result: BrowserNewsSearchResult = {
+        source: 'naver-stock-news',
+        topic,
+        sourceUrls,
+        articles,
+      };
+
+      if (params.runId) {
+        const artifact = await saveBrowserTextArtifact({
+          runId: params.runId,
+          scope: 'news',
+          ticker: params.ticker ?? params.companyName ?? 'unknown',
+          fileName: `naver-stock-news-${topic}.json`,
+          contentType: 'application/json',
+          text: JSON.stringify(result, null, 2),
+        });
+        result.artifactPath = artifact.path;
+      }
+
+      return toolResult(JSON.stringify(result));
+    },
+  };
+}
+
+export const browserNewsSearchTool = createBrowserNewsSearchTool();
+
+export function buildNaverDomesticStockNewsUrl(ticker: string): string {
+  return `${NAVER_DOMESTIC_STOCK_BASE_URL}/${ticker}/news`;
+}
+
+export function buildNaverWorldStockNewsUrl(ticker: string): string {
+  return `${NAVER_WORLD_STOCK_BASE_URL}/${stripWorldStockSuffix(ticker)}.O/worldnews`;
+}
+
+export function getNaverStockNewsUrls(
+  topic: NaverStockNewsTopic,
+  input: { ticker?: string } = {},
+): string[] {
+  const koreanTicker = normalizeKoreanTicker(input.ticker);
+  if (koreanTicker) return [buildNaverDomesticStockNewsUrl(koreanTicker)];
+
+  const worldTicker = normalizeWorldStockTicker(input.ticker);
+  if (worldTicker) return [buildNaverWorldStockNewsUrl(worldTicker)];
+
+  if (topic === 'all') {
+    return [
+      NAVER_STOCK_NEWS_TOPIC_URLS.flashnews,
+      NAVER_STOCK_NEWS_TOPIC_URLS['company-analysis'],
+      NAVER_STOCK_NEWS_TOPIC_URLS['market-outlook'],
+    ];
+  }
+  return [NAVER_STOCK_NEWS_TOPIC_URLS[topic]];
+}
+
+export function normalizeBrowserNewsArticles(
+  payload: unknown,
+  context: {
+    topic: NaverStockNewsTopic;
+    sourceUrls: string[];
+    query?: string;
+    ticker?: string;
+    companyName?: string;
+    limit: number;
+  },
+): BrowserNewsArticle[] {
+  const rawArticles = extractRawArticles(payload);
+  const filters = buildNewsFilters(context);
+
+  return rawArticles
+    .map((article, index) => normalizeBrowserNewsArticle(article, context, index))
+    .filter((article): article is BrowserNewsArticle => article !== undefined)
+    .filter((article) => matchesNewsFilters(article, filters))
+    .slice(0, context.limit);
+}
+
+export function buildNaverStockNewsInstruction(input: {
+  topic: NaverStockNewsTopic;
+  sourceUrls: string[];
+  query?: string;
+  ticker?: string;
+  companyName?: string;
+  limit?: number;
+}): string {
+  return [
+    'Open Naver Stock News pages and extract article metadata as JSON.',
+    `Source URLs: ${input.sourceUrls.join(', ')}`,
+    `Topic: ${input.topic}`,
+    input.query ? `Filter keyword: ${input.query}` : '',
+    input.ticker ? `Ticker: ${input.ticker}` : '',
+    input.companyName ? `Company: ${input.companyName}` : '',
+    `Limit: ${input.limit ?? 20}`,
+    'If a source URL is /domestic/stock/{ticker}/news or /worldstock/stock/{ticker}.O/worldnews, treat the page as already scoped to that company.',
+    'Return only JSON: {"articles":[{"title":"","url":"","publisher":"","publishedAt":"","summary":"","topic":"","sourceUrl":""}]}',
+    'Do not include article body text.',
+  ]
+    .filter(Boolean)
+    .join('\n');
+}
+
+function parseBrowserNewsStdout(stdout: string): unknown {
+  try {
+    return JSON.parse(stdout);
+  } catch {
+    return { articles: [] };
+  }
+}
+
+function extractRawArticles(payload: unknown): RawBrowserArticle[] {
+  if (Array.isArray(payload)) return payload as RawBrowserArticle[];
+  if (
+    payload &&
+    typeof payload === 'object' &&
+    Array.isArray((payload as { articles?: unknown }).articles)
+  ) {
+    return (payload as { articles: RawBrowserArticle[] }).articles;
+  }
+  return [];
+}
+
+function normalizeBrowserNewsArticle(
+  article: RawBrowserArticle,
+  context: {
+    topic: NaverStockNewsTopic;
+    sourceUrls: string[];
+  },
+  index: number,
+): BrowserNewsArticle | undefined {
+  const title = stringValue(article.title) ?? stringValue(article.headline);
+  const rawUrl = stringValue(article.url) ?? stringValue(article.link);
+  if (!title || !rawUrl) return undefined;
+
+  const topic =
+    normalizeTopic(stringValue(article.topic)) ??
+    topicFromSourceUrl(
+      stringValue(article.sourceUrl) ?? context.sourceUrls[index] ?? context.sourceUrls[0],
+    ) ??
+    (context.topic === 'all' ? 'flashnews' : context.topic);
+  const sourceUrl =
+    stringValue(article.sourceUrl) ??
+    context.sourceUrls[index] ??
+    context.sourceUrls[0] ??
+    NAVER_STOCK_NEWS_TOPIC_URLS[topic];
+
+  return {
+    title,
+    url: normalizeNaverNewsUrl(rawUrl),
+    publisher: stringValue(article.publisher) ?? stringValue(article.source),
+    publishedAt:
+      stringValue(article.publishedAt) ?? stringValue(article.date) ?? stringValue(article.time),
+    summary: stringValue(article.summary),
+    topic,
+    sourceUrl,
+  };
+}
+
+function buildNewsFilters(context: {
+  sourceUrls: string[];
+  query?: string;
+  ticker?: string;
+  companyName?: string;
+}): string[] {
+  const values = isStockSpecificNewsSource(context.sourceUrls, context.ticker)
+    ? [context.query]
+    : [context.query, context.ticker, context.companyName];
+
+  return values
+    .map((value) => value?.trim().toLowerCase())
+    .filter((value): value is string => Boolean(value));
+}
+
+function matchesNewsFilters(article: BrowserNewsArticle, filters: string[]): boolean {
+  if (filters.length === 0) return true;
+  const haystack = [article.title, article.summary, article.publisher]
+    .filter(Boolean)
+    .join('\n')
+    .toLowerCase();
+  return filters.some((filter) => haystack.includes(filter));
+}
+
+function normalizeNaverNewsUrl(url: string): string {
+  return new URL(url, NAVER_STOCK_NEWS_BASE_URL).href;
+}
+
+function normalizeTopic(
+  value: string | undefined,
+): Exclude<NaverStockNewsTopic, 'all'> | undefined {
+  if (!value || value === 'all') return undefined;
+  return value in NAVER_STOCK_NEWS_TOPIC_URLS
+    ? (value as Exclude<NaverStockNewsTopic, 'all'>)
+    : undefined;
+}
+
+function topicFromSourceUrl(
+  sourceUrl: string | undefined,
+): Exclude<NaverStockNewsTopic, 'all'> | undefined {
+  if (!sourceUrl) return undefined;
+  if (isDomesticStockNewsUrl(sourceUrl)) return 'company-analysis';
+  if (isWorldStockNewsUrl(sourceUrl)) return 'worldnews';
+  const found = Object.entries(NAVER_STOCK_NEWS_TOPIC_URLS).find(([, url]) => url === sourceUrl);
+  return found?.[0] as Exclude<NaverStockNewsTopic, 'all'> | undefined;
+}
+
+function isStockSpecificNewsSource(sourceUrls: string[], ticker?: string): boolean {
+  const koreanTicker = normalizeKoreanTicker(ticker);
+  if (koreanTicker) {
+    return sourceUrls.some((sourceUrl) =>
+      sourceUrl.startsWith(buildNaverDomesticStockNewsUrl(koreanTicker)),
+    );
+  }
+
+  const worldTicker = normalizeWorldStockTicker(ticker);
+  if (worldTicker) {
+    return sourceUrls.some((sourceUrl) =>
+      sourceUrl.startsWith(buildNaverWorldStockNewsUrl(worldTicker)),
+    );
+  }
+
+  return sourceUrls.some(
+    (sourceUrl) => isDomesticStockNewsUrl(sourceUrl) || isWorldStockNewsUrl(sourceUrl),
+  );
+}
+
+function isDomesticStockNewsUrl(sourceUrl: string): boolean {
+  try {
+    const url = new URL(sourceUrl);
+    return /^\/domestic\/stock\/\d{6}\/news\/?$/.test(url.pathname);
+  } catch {
+    return false;
+  }
+}
+
+function isWorldStockNewsUrl(sourceUrl: string): boolean {
+  try {
+    const url = new URL(sourceUrl);
+    return /^\/worldstock\/stock\/[A-Z0-9.-]+\.O\/worldnews\/?$/i.test(url.pathname);
+  } catch {
+    return false;
+  }
+}
+
+function normalizeKoreanTicker(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed && /^\d{6}$/.test(trimmed) ? trimmed : undefined;
+}
+
+function normalizeWorldStockTicker(value: string | undefined): string | undefined {
+  const trimmed = value ? stripWorldStockSuffix(value) : undefined;
+  if (!trimmed) return undefined;
+  return /^[A-Z][A-Z0-9.-]{0,14}$/.test(trimmed) ? trimmed : undefined;
+}
+
+function stripWorldStockSuffix(value: string): string {
+  const trimmed = value.trim().toUpperCase();
+  return trimmed.endsWith('.O') ? trimmed.slice(0, -2) : trimmed;
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() ? value.trim() : undefined;
+}

--- a/tests/agents/orchestration.test.ts
+++ b/tests/agents/orchestration.test.ts
@@ -104,8 +104,9 @@ describe('agent orchestration', () => {
     );
 
     expect(result).toMatchObject({ ticker: '000660' });
-    expect(sessions[0]?.options.customTools?.map((tool) => tool.name).slice(0, 4)).toEqual([
+    expect(sessions[0]?.options.customTools?.map((tool) => tool.name).slice(0, 5)).toEqual([
       'news_search',
+      'browser_news_search',
       'rpc_lookup',
       'memory_read',
       'memory_search',

--- a/tests/browser/agentBrowser.test.ts
+++ b/tests/browser/agentBrowser.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  AgentBrowserClient,
+  type AgentBrowserCommand,
+  type AgentBrowserRunnerOptions,
+  deterministicSessionName,
+  redactBrowserOutput,
+} from '../../src/browser/agentBrowser.js';
+
+describe('AgentBrowserClient', () => {
+  it('passes deterministic session name and timeout to the runner', async () => {
+    const calls: Array<{ command: AgentBrowserCommand; options: AgentBrowserRunnerOptions }> = [];
+    const runner = {
+      run: vi.fn(async (command: AgentBrowserCommand, options: AgentBrowserRunnerOptions) => {
+        calls.push({ command, options });
+        return { stdout: '{"ok":true}', stderr: '', exitCode: 0 };
+      }),
+    };
+    const client = new AgentBrowserClient({
+      runner,
+      bin: 'agent-browser-test',
+      timeoutMs: 1234,
+      runDoctor: false,
+    });
+
+    const result = await client.runTask({
+      instruction: 'Open Naver news and extract articles',
+      sessionNameSeed: 'News: 005930 / Latest',
+    });
+
+    expect(result).toMatchObject({ ok: true, sessionName: 'dure-news-005930-latest' });
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.command).toEqual({
+      command: 'agent-browser-test',
+      args: [
+        'run',
+        '--session',
+        'dure-news-005930-latest',
+        '--output',
+        'json',
+        '--prompt',
+        'Open Naver news and extract articles',
+      ],
+    });
+    expect(calls[0]?.options.timeoutMs).toBe(1234);
+  });
+
+  it('runs doctor lazily once before browser tasks', async () => {
+    const runner = {
+      run: vi.fn(async () => ({ stdout: '{}', stderr: '', exitCode: 0 })),
+    };
+    const client = new AgentBrowserClient({ runner });
+
+    await client.runTask({ instruction: 'first', sessionNameSeed: 'first' });
+    await client.runTask({ instruction: 'second', sessionNameSeed: 'second' });
+
+    expect(runner.run.mock.calls.map(([command]) => command.args[0])).toEqual([
+      'doctor',
+      'run',
+      'run',
+    ]);
+  });
+
+  it('returns doctor failure without running the task', async () => {
+    const runner = {
+      run: vi.fn(async (command: AgentBrowserCommand) => {
+        if (command.args[0] === 'doctor') {
+          return { stdout: '', stderr: 'token=secret', exitCode: 1 };
+        }
+        return { stdout: '{}', stderr: '', exitCode: 0 };
+      }),
+    };
+    const client = new AgentBrowserClient({ runner });
+
+    const result = await client.runTask({ instruction: 'task', sessionNameSeed: 'task' });
+
+    expect(result).toEqual({
+      ok: false,
+      error: {
+        code: 'AGENT_BROWSER_DOCTOR_FAILED',
+        message: 'agent-browser doctor failed with exit code 1',
+        stdout: '',
+        stderr: 'token=[REDACTED]',
+      },
+    });
+    expect(runner.run).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns install guidance when agent-browser is missing', async () => {
+    const missing = Object.assign(new Error('spawn agent-browser ENOENT'), { code: 'ENOENT' });
+    const runner = {
+      run: vi.fn(async () => {
+        throw missing;
+      }),
+    };
+    const client = new AgentBrowserClient({ runner });
+
+    const result = await client.doctor();
+
+    expect(result).toMatchObject({
+      ok: false,
+      error: {
+        code: 'AGENT_BROWSER_NOT_INSTALLED',
+      },
+    });
+  });
+});
+
+describe('agent-browser helpers', () => {
+  it('redacts token, query, cookie, and authorization shaped secrets', () => {
+    const redacted = redactBrowserOutput(
+      [
+        'https://example.test/path?token=secret&ok=1',
+        'api_key: abc123',
+        'Cookie: sid=abc; theme=light',
+        'Authorization: Bearer secret',
+      ].join('\n'),
+    );
+
+    expect(redacted).toContain('token=[REDACTED]');
+    expect(redacted).toContain('api_key: [REDACTED]');
+    expect(redacted).toContain('Cookie: [REDACTED]');
+    expect(redacted).toContain('Authorization: [REDACTED]');
+    expect(redacted).not.toContain('abc123');
+    expect(redacted).not.toContain('Bearer secret');
+  });
+
+  it('builds stable session names', () => {
+    expect(deterministicSessionName(' News: 005930 / 최신 ')).toBe('dure-news-005930');
+  });
+});

--- a/tests/pi/resources.test.ts
+++ b/tests/pi/resources.test.ts
@@ -42,6 +42,23 @@ describe('Pi project resources', () => {
     expect(pi.registerCommand).not.toHaveBeenCalled();
   });
 
+  it('browser extension registers only browser manual tools', async () => {
+    const extension = await import('../../.pi/extensions/dure-browser/index.ts');
+    const pi = {
+      exec: vi.fn(),
+      registerTool: vi.fn(),
+    };
+
+    extension.default(pi);
+
+    const toolNames = pi.registerTool.mock.calls.map(([tool]) => tool.name);
+    expect(toolNames).toEqual([
+      'browser_doctor',
+      'browser_news_search',
+      'browser_capture_evidence',
+    ]);
+  });
+
   it('slash UX is represented as project prompt templates', () => {
     const prompts = ['equity', 'screen', 'strategy', 'scenario', 'review'];
 
@@ -58,7 +75,7 @@ describe('Pi project resources', () => {
   });
 
   it('initial skills follow Pi skill naming and description rules', () => {
-    const skills = ['dure-investing-workflows', 'cluefin-data-discovery'];
+    const skills = ['dure-investing-workflows', 'cluefin-data-discovery', 'dure-browser'];
 
     for (const skill of skills) {
       const path = `.pi/skills/${skill}/SKILL.md`;
@@ -70,5 +87,15 @@ describe('Pi project resources', () => {
       expect(frontmatter.description.length).toBeGreaterThan(20);
       expect(frontmatter.description.length).toBeLessThanOrEqual(1024);
     }
+  });
+
+  it('dure browser skill documents browser news boundaries', () => {
+    const content = readProjectFile('.pi/skills/dure-browser/SKILL.md');
+
+    expect(content).toContain('browser_news_search');
+    expect(content).toContain('https://stock.naver.com/news');
+    expect(content).toContain('browser_capture_evidence');
+    expect(content).not.toContain('browser_research_search');
+    expect(content).not.toContain('pdf_analyze');
   });
 });

--- a/tests/runtime/browserArtifacts.test.ts
+++ b/tests/runtime/browserArtifacts.test.ts
@@ -1,0 +1,83 @@
+import { mkdir, readFile, rm } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const originalCwd = process.cwd();
+let tmpDir: string;
+
+beforeEach(async () => {
+  tmpDir = path.join(os.tmpdir(), `browser-artifacts-test-${Date.now()}-${Math.random()}`);
+  await mkdir(tmpDir, { recursive: true });
+  process.chdir(tmpDir);
+  vi.resetModules();
+});
+
+afterEach(async () => {
+  process.chdir(originalCwd);
+  await rm(tmpDir, { recursive: true, force: true });
+  vi.restoreAllMocks();
+});
+
+describe('browser artifact helpers', () => {
+  it('keeps artifact paths inside the run directory', async () => {
+    const { resolveBrowserArtifactPath, resolveScopedBrowserArtifactPath } = await import(
+      '../../src/runtime/browserArtifacts.js'
+    );
+
+    const newsPath = resolveScopedBrowserArtifactPath({
+      runId: 'run-1',
+      scope: 'news',
+      ticker: '005930',
+      fileName: 'naver-news.json',
+      contentType: 'application/json',
+    });
+    expect(newsPath).toBe(path.resolve('data/runs/run-1/news/005930/browser/naver-news.json'));
+    expect(() => resolveBrowserArtifactPath('run-1', ['..', 'escape.json'])).toThrow(
+      /escapes run directory/,
+    );
+  });
+
+  it('writes and reads text artifact metadata', async () => {
+    const { readBrowserArtifactMetadata, saveBrowserTextArtifact } = await import(
+      '../../src/runtime/browserArtifacts.js'
+    );
+
+    const metadata = await saveBrowserTextArtifact({
+      runId: 'run-2',
+      scope: 'news',
+      ticker: '000660',
+      fileName: 'flashnews.json',
+      contentType: 'application/json',
+      sourceUrl: 'https://stock.naver.com/news/flashnews',
+      label: 'flashnews',
+      text: JSON.stringify({ articles: [{ title: 'HBM' }] }),
+    });
+
+    expect(metadata).toMatchObject({
+      relativePath: 'run-2/news/000660/browser/flashnews.json',
+      kind: 'text',
+      contentType: 'application/json',
+      sourceUrl: 'https://stock.naver.com/news/flashnews',
+      label: 'flashnews',
+    });
+    await expect(readFile(metadata.path, 'utf-8')).resolves.toContain('HBM');
+    await expect(readBrowserArtifactMetadata(metadata.path)).resolves.toMatchObject({
+      path: metadata.path,
+      sizeBytes: metadata.sizeBytes,
+    });
+  });
+
+  it('does not change existing ArtifactStore JSON behavior', async () => {
+    const { ArtifactStore } = await import('../../src/runtime/artifactStore.js');
+    const store = new ArtifactStore();
+
+    await store.put('run-4', 'news', '005930', { ticker: '005930', catalysts: ['HBM'] });
+
+    await expect(store.get('run-4', 'news', '005930')).resolves.toEqual({
+      ticker: '005930',
+      catalysts: ['HBM'],
+    });
+    await expect(readFile('data/runs/run-4/news/005930.json', 'utf-8')).resolves.toContain('HBM');
+  });
+});

--- a/tests/schemas/newsAnalysis.test.ts
+++ b/tests/schemas/newsAnalysis.test.ts
@@ -1,0 +1,51 @@
+import { Value } from '@sinclair/typebox/value';
+import { describe, expect, it } from 'vitest';
+import { NewsAnalysisSchema } from '../../src/schemas/analysis.js';
+
+describe('NewsAnalysisSchema', () => {
+  it('accepts existing news analysis JSON without sources', () => {
+    expect(
+      Value.Check(NewsAnalysisSchema, {
+        ticker: '005930',
+        eventTimeline: [
+          {
+            date: '2026-05-24',
+            headline: '삼성전자 HBM 공급 기대',
+            impact: '긍정: AI 수요 확대',
+          },
+        ],
+        sentimentSummary: '우호적',
+        catalysts: ['HBM 수요'],
+        risks: ['메모리 가격 변동성'],
+      }),
+    ).toBe(true);
+  });
+
+  it('accepts Naver browser source metadata', () => {
+    expect(
+      Value.Check(NewsAnalysisSchema, {
+        ticker: '005930',
+        eventTimeline: [
+          {
+            date: '2026-05-24',
+            headline: '삼성전자 HBM 공급 기대',
+            impact: '긍정: AI 수요 확대',
+          },
+        ],
+        sentimentSummary: '우호적',
+        catalysts: ['HBM 수요'],
+        risks: ['메모리 가격 변동성'],
+        sources: [
+          {
+            title: '삼성전자 HBM 공급 기대',
+            url: 'https://n.news.naver.com/article/001/0000000001',
+            publisher: '연합뉴스',
+            publishedAt: '2026.05.24',
+            topic: 'company-analysis',
+            sourceUrl: 'https://stock.naver.com/news/section?tab=company-analysis',
+          },
+        ],
+      }),
+    ).toBe(true);
+  });
+});

--- a/tests/tools/browserNewsTool.test.ts
+++ b/tests/tools/browserNewsTool.test.ts
@@ -1,0 +1,265 @@
+import { mkdir, rm } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { AgentBrowserClient } from '../../src/browser/agentBrowser.js';
+import {
+  buildNaverDomesticStockNewsUrl,
+  buildNaverWorldStockNewsUrl,
+  createBrowserNewsSearchTool,
+  getNaverStockNewsUrls,
+  normalizeBrowserNewsArticles,
+} from '../../src/tools/browserNewsTool.js';
+
+const originalCwd = process.cwd();
+let tmpDir: string;
+
+beforeEach(async () => {
+  tmpDir = path.join(os.tmpdir(), `browser-news-tool-test-${Date.now()}-${Math.random()}`);
+  await mkdir(tmpDir, { recursive: true });
+  process.chdir(tmpDir);
+});
+
+afterEach(async () => {
+  process.chdir(originalCwd);
+  await rm(tmpDir, { recursive: true, force: true });
+  vi.restoreAllMocks();
+});
+
+describe('browserNewsSearchTool', () => {
+  it('maps Naver stock news topics to fast source URLs', () => {
+    expect(getNaverStockNewsUrls('company-analysis')).toEqual([
+      'https://stock.naver.com/news/section?tab=company-analysis',
+    ]);
+    expect(getNaverStockNewsUrls('all')).toEqual([
+      'https://stock.naver.com/news/flashnews',
+      'https://stock.naver.com/news/section?tab=company-analysis',
+      'https://stock.naver.com/news/section?tab=market-outlook',
+    ]);
+    expect(getNaverStockNewsUrls('all', { ticker: '203650' })).toEqual([
+      'https://stock.naver.com/domestic/stock/203650/news',
+    ]);
+    expect(buildNaverDomesticStockNewsUrl('203650')).toBe(
+      'https://stock.naver.com/domestic/stock/203650/news',
+    );
+    expect(getNaverStockNewsUrls('all', { ticker: 'AAPL' })).toEqual([
+      'https://stock.naver.com/worldstock/stock/AAPL.O/worldnews',
+    ]);
+    expect(getNaverStockNewsUrls('all', { ticker: 'AAPL.O' })).toEqual([
+      'https://stock.naver.com/worldstock/stock/AAPL.O/worldnews',
+    ]);
+    expect(buildNaverWorldStockNewsUrl('AAPL')).toBe(
+      'https://stock.naver.com/worldstock/stock/AAPL.O/worldnews',
+    );
+    expect(buildNaverWorldStockNewsUrl('AAPL.O')).toBe(
+      'https://stock.naver.com/worldstock/stock/AAPL.O/worldnews',
+    );
+  });
+
+  it('normalizes article URLs, topics, and client-side filters', () => {
+    const articles = normalizeBrowserNewsArticles(
+      {
+        articles: [
+          {
+            title: '삼성전자 HBM 공급 기대',
+            link: '/news/worldnews/123',
+            source: '한국경제',
+            time: '2026.05.24 09:10',
+            summary: 'AI 반도체 수요',
+            sourceUrl: 'https://stock.naver.com/news/worldnews',
+          },
+          {
+            title: '원달러 환율 상승',
+            url: 'https://n.news.naver.com/article/001/0000000000',
+          },
+        ],
+      },
+      {
+        topic: 'all',
+        sourceUrls: getNaverStockNewsUrls('all'),
+        companyName: '삼성전자',
+        limit: 10,
+      },
+    );
+
+    expect(articles).toEqual([
+      {
+        title: '삼성전자 HBM 공급 기대',
+        url: 'https://stock.naver.com/news/worldnews/123',
+        publisher: '한국경제',
+        publishedAt: '2026.05.24 09:10',
+        summary: 'AI 반도체 수요',
+        topic: 'worldnews',
+        sourceUrl: 'https://stock.naver.com/news/worldnews',
+      },
+    ]);
+  });
+
+  it('does not ticker-filter articles from stock-scoped news pages', () => {
+    const domesticArticles = normalizeBrowserNewsArticles(
+      {
+        articles: [
+          {
+            title: '美 정부 양자컴 베팅 소식에 테마주 강세',
+            url: 'https://n.news.naver.com/article/011/0004623839',
+            source: '서울경제',
+            date: '2026. 05. 23.',
+          },
+        ],
+      },
+      {
+        topic: 'all',
+        sourceUrls: getNaverStockNewsUrls('all', { ticker: '203650' }),
+        ticker: '203650',
+        limit: 10,
+      },
+    );
+
+    expect(domesticArticles).toEqual([
+      {
+        title: '美 정부 양자컴 베팅 소식에 테마주 강세',
+        url: 'https://n.news.naver.com/article/011/0004623839',
+        publisher: '서울경제',
+        publishedAt: '2026. 05. 23.',
+        topic: 'company-analysis',
+        sourceUrl: 'https://stock.naver.com/domestic/stock/203650/news',
+      },
+    ]);
+
+    const worldArticles = normalizeBrowserNewsArticles(
+      {
+        articles: [
+          {
+            title: 'AI 투자 확대로 빅테크 실적 기대',
+            url: 'https://n.news.naver.com/article/001/0000000002',
+            source: '연합뉴스',
+            date: '2026. 05. 24.',
+          },
+        ],
+      },
+      {
+        topic: 'all',
+        sourceUrls: getNaverStockNewsUrls('all', { ticker: 'AAPL' }),
+        ticker: 'AAPL',
+        limit: 10,
+      },
+    );
+
+    expect(worldArticles).toEqual([
+      {
+        title: 'AI 투자 확대로 빅테크 실적 기대',
+        url: 'https://n.news.naver.com/article/001/0000000002',
+        publisher: '연합뉴스',
+        publishedAt: '2026. 05. 24.',
+        topic: 'worldnews',
+        sourceUrl: 'https://stock.naver.com/worldstock/stock/AAPL.O/worldnews',
+      },
+    ]);
+  });
+
+  it('runs agent-browser with Naver topic URL and returns metadata only', async () => {
+    const runner = {
+      run: vi.fn(async () => ({
+        stdout: JSON.stringify({
+          articles: [
+            {
+              title: '삼성전자, AI 수요 확대',
+              url: 'https://n.news.naver.com/article/001/0000000001',
+              publisher: '연합뉴스',
+              publishedAt: '2026.05.24',
+            },
+          ],
+        }),
+        stderr: '',
+        exitCode: 0,
+      })),
+    };
+    const client = new AgentBrowserClient({ runner, runDoctor: false });
+    const tool = createBrowserNewsSearchTool({ client });
+
+    const result = await tool.execute(
+      'tool-1',
+      {
+        topic: 'company-analysis',
+        query: '삼성',
+        ticker: '005930',
+        limit: 1,
+        runId: 'run-news-1',
+      },
+      undefined,
+      undefined,
+      {} as never,
+    );
+    const payload = JSON.parse(result.content[0].text);
+
+    expect(runner.run.mock.calls[0]?.[0].args.join('\n')).toContain(
+      'https://stock.naver.com/domestic/stock/005930/news',
+    );
+    expect(payload).toMatchObject({
+      source: 'naver-stock-news',
+      topic: 'company-analysis',
+      articles: [
+        {
+          title: '삼성전자, AI 수요 확대',
+          publisher: '연합뉴스',
+          topic: 'company-analysis',
+        },
+      ],
+    });
+    expect(payload.artifactPath).toContain('data/runs/run-news-1/news/005930/browser');
+    expect(JSON.stringify(payload)).not.toContain('article body');
+  });
+
+  it('runs agent-browser with Naver worldstock URL for overseas tickers', async () => {
+    const runner = {
+      run: vi.fn(async () => ({
+        stdout: JSON.stringify({
+          articles: [
+            {
+              title: '애플, AI 투자 확대 기대',
+              url: 'https://n.news.naver.com/article/001/0000000003',
+              publisher: '연합뉴스',
+              publishedAt: '2026.05.24',
+            },
+          ],
+        }),
+        stderr: '',
+        exitCode: 0,
+      })),
+    };
+    const client = new AgentBrowserClient({ runner, runDoctor: false });
+    const tool = createBrowserNewsSearchTool({ client });
+
+    const result = await tool.execute(
+      'tool-2',
+      {
+        topic: 'worldnews',
+        ticker: 'AAPL',
+        limit: 1,
+        runId: 'run-news-2',
+      },
+      undefined,
+      undefined,
+      {} as never,
+    );
+    const payload = JSON.parse(result.content[0].text);
+
+    expect(runner.run.mock.calls[0]?.[0].args.join('\n')).toContain(
+      'https://stock.naver.com/worldstock/stock/AAPL.O/worldnews',
+    );
+    expect(payload).toMatchObject({
+      source: 'naver-stock-news',
+      topic: 'worldnews',
+      sourceUrls: ['https://stock.naver.com/worldstock/stock/AAPL.O/worldnews'],
+      articles: [
+        {
+          title: '애플, AI 투자 확대 기대',
+          publisher: '연합뉴스',
+          topic: 'worldnews',
+          sourceUrl: 'https://stock.naver.com/worldstock/stock/AAPL.O/worldnews',
+        },
+      ],
+    });
+    expect(payload.artifactPath).toContain('data/runs/run-news-2/news/AAPL/browser');
+  });
+});

--- a/tests/tools/workflowTools.test.ts
+++ b/tests/tools/workflowTools.test.ts
@@ -103,7 +103,7 @@ describe('workflowTools', () => {
 
     await expect(
       scenarioAnalysisTool.execute(
-        'tool-4',
+        'tool-5',
         { scenario: 'rate cut', tickers: ['005930'] },
         undefined,
         undefined,


### PR DESCRIPTION
## Summary
- Naver 증권 뉴스 페이지를 브라우저 기반으로 조회해 실제 기사 링크와 메타데이터를 수집할 수 있게 했습니다.
- 국내/해외 종목별 뉴스 URL을 우선 사용해 기업 관련 뉴스는 해당 종목 페이지에서 확인하도록 했습니다.
- 리포트, research, PDF 다운로드/분석 도구는 최종 범위에서 제거하고 뉴스와 일반 브라우저 증거 캡처만 유지했습니다.

## Related Issue / Context
- N/A

## What Changed
- 브라우저 실행 코어
  - `AgentBrowserClient`를 추가해 `agent-browser doctor/run` 실행, 결정적 세션 이름 생성, 실패 코드 정규화, 민감 토큰 redaction을 처리했습니다.
  - 브라우저 실행 결과와 세션 이름 생성 규칙을 테스트로 고정했습니다.
- Naver 증권 뉴스 수집
  - `browser_news_search` 도구를 추가해 Naver 증권 뉴스에서 제목, URL, 언론사, 게시 시각, 요약, topic, source URL을 JSON으로 반환합니다.
  - `flashnews`, `mainnews`, `ranknews`, `worldnews`, 시황/기업/글로벌/채권/공시/환율 등 기존 주제별 페이지를 지원합니다.
  - 6자리 국내 종목코드는 `https://stock.naver.com/domestic/stock/{ticker}/news`, 해외 종목은 `https://stock.naver.com/worldstock/stock/{ticker}/news` 페이지를 우선 사용합니다.
  - 종목별 페이지에서는 URL 경로가 이미 회사를 한정하므로 ticker 자체로 결과를 다시 필터링하지 않도록 조정했습니다.
- News agent / schema 통합
  - 뉴스 분석 에이전트가 `browser_news_search`를 사용할 수 있도록 custom tool 구성을 확장했습니다.
  - 뉴스 source schema에 Naver 증권 뉴스 metadata 필드를 추가했습니다.
  - `research/prompts/news.md`에 Naver 증권 뉴스 우선 사용 기준과 fallback 경계를 문서화했습니다.
- Artifact / Pi 통합
  - 브라우저 수집 결과를 `data/runs/{runId}/news/{ticker}/browser` 아래 JSON artifact로 저장하는 helper를 추가했습니다.
  - `.pi/extensions/dure-browser`에 `browser_doctor`, `browser_news_search`, `browser_capture_evidence`만 등록했습니다.
  - `.pi/skills/dure-browser/SKILL.md`에서 리포트/research/PDF 경로를 제거하고 뉴스/증거 캡처 경계만 남겼습니다.
- 제외된 범위
  - Naver research/report 검색, 리포트 PDF 저장, PDF 본문/차트 분석 도구는 제거했습니다.
  - 리포트나 PDF 내용 판단은 도구가 수행하지 않고, 사용자가 직접 링크나 문서를 읽는 흐름으로 남깁니다.

## Verification
- `npm test`
- Result: pass, 33 test files and 162 tests passed
- `npm run lint`
- Result: pass, Biome checked 84 files with no fixes applied
- `npm run build`
- Result: pass, TypeScript compilation completed successfully
- `npm run format`
- Result: pass, Biome formatted 84 files after the final scope update

## Breaking Changes / Migration Notes
- `run_report_research`, `browser_research_search`, `browser_research_capture_pdf`, `research_pdf_analyze`/`pdf_analyze` are not exposed in the final PR scope.
- Consumers should use `browser_news_search` for news and handle research/report/PDF reading outside these tools.
